### PR TITLE
fix: resolve critical Firestore data model issues

### DIFF
--- a/docs/firestore-schema.md
+++ b/docs/firestore-schema.md
@@ -13,6 +13,7 @@ This document describes the Firestore collections used by SAHA-Care.
 | `caseDefinitions` | WHO-aligned disease definitions | Officials only | All authenticated users |
 | `alerts` | Outbreak alerts | Cloud Functions only | Supervisors, Officials |
 | `aggregates` | Pre-computed dashboard data | Cloud Functions only | Supervisors, Officials |
+| `auditLogs` | Approval/rejection audit trail | Cloud Functions only | Officials |
 
 ---
 
@@ -29,6 +30,11 @@ interface User {
   status: 'pending' | 'approved' | 'rejected';
   supervisorId?: string;    // UID of assigned supervisor (volunteers only)
   region: string;           // Geographic region
+  approvedBy?: string;      // UID of the user who approved this account
+  approvedAt?: Timestamp;   // When the account was approved
+  rejectedBy?: string;      // UID of the user who rejected this account
+  rejectedAt?: Timestamp;   // When the account was rejected
+  rejectionReason?: string; // Reason for rejection (required on rejection)
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }
@@ -36,7 +42,10 @@ interface User {
 
 **Document ID:** User's Firebase Auth UID
 
-**Indexes:** None required (queries by region use security rules)
+**Indexes:**
+- `region` + `role` + `status`
+- `role` + `status` + `createdAt`
+- `role` + `status` + `region` + `createdAt`
 
 ---
 
@@ -47,8 +56,9 @@ Disease case reports submitted by volunteers.
 ```typescript
 interface Report {
   id: string;               // Auto-generated document ID
-  disease: string;          // References caseDefinitions.id
-  symptoms: string[];       // Selected symptom IDs from case definition
+  disease: string;          // References caseDefinitions.disease
+  answers: QuestionAnswer[]; // Structured answers to assessment questions
+  symptoms: string[];       // Flat list of "Yes" answer texts (for display)
   temp?: number;            // Patient temperature in Celsius
   dangerSigns?: string[];   // Observed danger signs
   location: {
@@ -62,8 +72,19 @@ interface Report {
   region: string;           // Region where report was filed
   verifiedBy?: string;      // UID of verifying supervisor
   verificationNotes?: string;
+  hasDangerSigns: boolean;  // Whether any danger sign was flagged
+  isImmediateReport: boolean; // Whether flagged for immediate alert
+  personsCount: number;     // Number of persons affected (minimum 1)
+  reclassifiedFrom?: string; // Original disease if reclassification occurred
   createdAt: Timestamp;
   verifiedAt?: Timestamp;
+}
+
+interface QuestionAnswer {
+  questionId: string;
+  questionText: string;     // Denormalized for offline readability
+  answer: boolean;
+  numericValue?: number;    // Numeric follow-up value if applicable
 }
 ```
 
@@ -71,8 +92,10 @@ interface Report {
 
 **Indexes:**
 - `region` + `status` + `createdAt` (supervisor pending reports query)
+- `region` + `createdAt` (dashboard reports by region)
 - `reporterId` + `createdAt` (volunteer's own reports)
-- `disease` + `region` + `createdAt` (dashboard filtering)
+- `region` + `disease` + `createdAt` (dashboard filtering)
+- `disease` + `region` + `status` + `createdAt` (threshold queries)
 
 ---
 
@@ -84,15 +107,34 @@ WHO-aligned case definitions for reportable diseases.
 interface CaseDefinition {
   id: string;               // URL-safe slug (e.g., "acute-watery-diarrhea")
   disease: string;          // Display name
-  symptoms: Array<{
-    id: string;
-    name: string;
-    required: boolean;      // Required for suspected case
-  }>;
+  definition: string;       // Short clinical definition
+  questions: AssessmentQuestion[]; // Structured assessment questions
   dangerSigns: string[];    // Red flags requiring referral
   guidance: string;         // Clinical guidance for CHWs
   active: boolean;          // Whether currently in use
-  threshold: number;        // Alert threshold (cases per region)
+  thresholds: AlertThreshold[]; // Alert thresholds with time windows
+  prioritySurveillance: boolean; // Whether this is a priority target
+}
+
+interface AssessmentQuestion {
+  id: string;
+  text: string;             // Yes/No question text
+  category: 'core' | 'associated' | 'severity' | 'history';
+  required: boolean;        // Required for suspected case
+  inputType: 'none' | 'number';
+  inputLabel?: string;
+  inputUnit?: string;
+  yesNote?: string;         // Note shown on "Yes" answer
+  isDangerSign: boolean;
+  isImmediateReport: boolean;
+  reclassifyTo?: string;    // Disease ID to reclassify to on "Yes"
+}
+
+interface AlertThreshold {
+  count: number;            // Cases that trigger alert
+  windowHours: number;      // Time window (24 = day, 168 = week)
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  description: string;
 }
 ```
 
@@ -113,8 +155,10 @@ interface Alert {
   region: string;           // Affected region
   caseCount: number;        // Current case count
   threshold: number;        // Threshold that was exceeded
+  windowHours: number;      // Time window of the threshold (in hours)
   severity: 'low' | 'medium' | 'high' | 'critical';
   status: 'active' | 'resolved';
+  immediateAlert: boolean;  // Whether triggered by immediate-report flag
   createdAt: Timestamp;
   resolvedAt?: Timestamp;
 }
@@ -123,8 +167,10 @@ interface Alert {
 **Document ID:** Auto-generated
 
 **Indexes:**
-- `status` + `createdAt` (active alerts query)
-- `region` + `status` (regional alerts)
+- `status` + `createdAt` (active alerts, all regions)
+- `status` + `severity` + `createdAt`
+- `region` + `status` + `createdAt` (regional alerts)
+- `disease` + `region` + `status` (dedup check)
 
 **Note:** Created exclusively by the `onReportWrite` Cloud Function.
 
@@ -136,12 +182,14 @@ Pre-computed rollups for dashboard performance.
 
 ```typescript
 interface Aggregate {
-  id: string;               // Composite: `{disease}_{region}_{period}_{date}`
+  id: string;               // Composite: `{disease-slug}_{region-slug}_{period}_{date}`
   disease: string;
   region: string;
   period: 'day' | 'week';
+  dateKey: string;          // Explicit date key (e.g., "2026-03-12")
   caseCount: number;
   verifiedCount: number;
+  personsCount: number;     // Total persons affected
   lastUpdated: Timestamp;
 }
 ```
@@ -149,10 +197,31 @@ interface Aggregate {
 **Document ID:** Composite key for upsert operations
 
 **Indexes:**
-- `disease` + `period` + `lastUpdated`
-- `region` + `period` + `lastUpdated`
+- `disease` + `region` + `period`
+- `period` + `region`
 
-**Note:** Maintained exclusively by the `aggregateCases` Cloud Function.
+**Note:** Maintained exclusively by the `aggregateCases` Cloud Function. Uses report's `createdAt` for time bucketing (not function execution time).
+
+---
+
+## `auditLogs`
+
+Audit trail for user approval and rejection actions. Created by the `onUserApproval` Cloud Function.
+
+```typescript
+interface AuditLog {
+  id: string;
+  action: string;           // e.g., "approve_user", "reject_user"
+  targetUid: string;        // UID of affected user
+  performedBy: string;      // UID of the approver/rejector
+  details: Record<string, unknown>; // Additional context
+  createdAt: Timestamp;
+}
+```
+
+**Document ID:** Auto-generated
+
+**Note:** No TTL/cleanup policy currently configured.
 
 ---
 
@@ -167,15 +236,17 @@ See `firestore.rules` for full implementation.
 | `caseDefinitions` | Read: all authenticated. Write: officials only. |
 | `alerts` | Read: supervisors/officials. Write: Cloud Functions only (no client writes). |
 | `aggregates` | Read: supervisors/officials. Write: Cloud Functions only. |
+| `auditLogs` | Read: officials only. Write: Cloud Functions only. |
 
 ---
 
 ## Offline Behavior
 
-Firestore offline persistence is enabled via `enableIndexedDbPersistence()`. This means:
+Firestore offline persistence is enabled via `initializeFirestore` with `persistentLocalCache` and `persistentMultipleTabManager`. This means:
 
 1. **Reads:** Cached data served when offline
 2. **Writes:** Queued locally, synced on reconnect
 3. **Listeners:** `onSnapshot` fires with cached data, updates on sync
+4. **Multi-tab:** Persistence works across multiple browser tabs
 
-Reports submitted offline will have `createdAt` set to client time and sync when connectivity returns.
+Reports submitted offline will have `createdAt` set to client time and sync when connectivity returns. Aggregates use the report's `createdAt` for time bucketing, ensuring offline-submitted reports are bucketed correctly.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -207,6 +207,52 @@
                     "order": "ASCENDING"
                 }
             ]
+        },
+        {
+            "collectionGroup": "alerts",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "status",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "createdAt",
+                    "order": "DESCENDING"
+                }
+            ]
+        },
+        {
+            "collectionGroup": "reports",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "createdAt",
+                    "order": "DESCENDING"
+                }
+            ]
+        },
+        {
+            "collectionGroup": "reports",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "disease",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "region",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "status",
+                    "order": "ASCENDING"
+                },
+                {
+                    "fieldPath": "createdAt",
+                    "order": "ASCENDING"
+                }
+            ]
         }
     ],
     "fieldOverrides": []

--- a/functions/src/aggregateCases.ts
+++ b/functions/src/aggregateCases.ts
@@ -43,13 +43,14 @@ export const aggregateCases = onDocumentWritten(
         // Ignore deletions
         if (!after) return;
 
-        const { disease, region, status, personsCount: rawPersonsCount } = after;
+        const { disease, region, status, personsCount: rawPersonsCount, createdAt } = after;
         const personsCount = typeof rawPersonsCount === 'number' && rawPersonsCount >= 1 ? rawPersonsCount : 1;
         const reportId = event.params.reportId;
 
-        const now = new Date();
-        const dayKey = now.toISOString().split('T')[0]; // "2026-03-12"
-        const weekKey = getWeekStart(now); // Monday of current week
+        // Use report's createdAt for bucketing (handles offline-submitted reports)
+        const reportDate = createdAt?.toDate ? createdAt.toDate() : new Date();
+        const dayKey = reportDate.toISOString().split('T')[0]; // "2026-03-12"
+        const weekKey = getWeekStart(reportDate); // Monday of report's week
 
         const diseaseSlug = slugify(disease);
         const regionSlug = slugify(region);
@@ -66,32 +67,32 @@ export const aggregateCases = onDocumentWritten(
             // New report created — increment case count
             logger.info('Aggregating new report', { reportId, disease, region });
 
-            const baseData = {
-                disease,
-                region,
-                lastUpdated: FieldValue.serverTimestamp(),
-            };
-
             const isVerified = status === 'verified';
 
             await dayRef.set(
                 {
-                    ...baseData,
+                    disease,
+                    region,
                     period: 'day',
+                    dateKey: dayKey,
                     caseCount: FieldValue.increment(1),
                     verifiedCount: FieldValue.increment(isVerified ? 1 : 0),
                     personsCount: FieldValue.increment(personsCount),
+                    lastUpdated: FieldValue.serverTimestamp(),
                 },
                 { merge: true }
             );
 
             await weekRef.set(
                 {
-                    ...baseData,
+                    disease,
+                    region,
                     period: 'week',
+                    dateKey: weekKey,
                     caseCount: FieldValue.increment(1),
                     verifiedCount: FieldValue.increment(isVerified ? 1 : 0),
                     personsCount: FieldValue.increment(personsCount),
+                    lastUpdated: FieldValue.serverTimestamp(),
                 },
                 { merge: true }
             );
@@ -99,18 +100,13 @@ export const aggregateCases = onDocumentWritten(
             // Report just verified — increment verified count only
             logger.info('Aggregating verified report', { reportId, disease, region });
 
-            const updateData = {
-                verifiedCount: FieldValue.increment(1),
-                lastUpdated: FieldValue.serverTimestamp(),
-            };
-
             await dayRef.set(
-                { disease, region, period: 'day', ...updateData },
+                { disease, region, period: 'day', dateKey: dayKey, verifiedCount: FieldValue.increment(1), lastUpdated: FieldValue.serverTimestamp() },
                 { merge: true }
             );
 
             await weekRef.set(
-                { disease, region, period: 'week', ...updateData },
+                { disease, region, period: 'week', dateKey: weekKey, verifiedCount: FieldValue.increment(1), lastUpdated: FieldValue.serverTimestamp() },
                 { merge: true }
             );
         }

--- a/functions/src/onReportWrite.ts
+++ b/functions/src/onReportWrite.ts
@@ -25,6 +25,7 @@ async function createAlertIfNeeded(
     disease: string,
     region: string,
     caseCount: number,
+    thresholdCount: number,
     windowHours: number,
     severity: string,
     immediateAlert: boolean
@@ -58,7 +59,7 @@ async function createAlertIfNeeded(
             disease,
             region,
             caseCount,
-            threshold: caseCount,
+            threshold: thresholdCount,
             windowHours,
             severity,
             status: 'active',
@@ -88,7 +89,7 @@ export const onReportWrite = onDocumentCreated(
         // 1. Handle immediate report flags (e.g., bloody diarrhea, measles rash)
         if (isImmediateReport) {
             logger.info('Immediate report flag detected', { reportId, disease });
-            await createAlertIfNeeded(disease, region, 1, 168, 'critical', true);
+            await createAlertIfNeeded(disease, region, 1, 1, 168, 'critical', true);
         }
 
         // 2. Look up case definition for threshold rules
@@ -112,11 +113,12 @@ export const onReportWrite = onDocumentCreated(
             const cutoffDate = new Date(Date.now() - threshold.windowHours * 60 * 60 * 1000);
             const cutoffTimestamp = Timestamp.fromDate(cutoffDate);
 
-            // Count reports in the time window for this disease+region
+            // Count non-rejected reports in the time window for this disease+region
             const reportsInWindow = await db
                 .collection('reports')
                 .where('disease', '==', disease)
                 .where('region', '==', region)
+                .where('status', 'in', ['pending', 'verified'])
                 .where('createdAt', '>=', cutoffTimestamp)
                 .get();
 
@@ -136,6 +138,7 @@ export const onReportWrite = onDocumentCreated(
                     disease,
                     region,
                     caseCount,
+                    threshold.count,
                     threshold.windowHours,
                     threshold.severity,
                     false

--- a/src/components/charts/CasesOverTimeChart.tsx
+++ b/src/components/charts/CasesOverTimeChart.tsx
@@ -14,9 +14,8 @@ export default function CasesOverTimeChart() {
         // Use aggregates if available, otherwise compute from reports
         if (filteredAggregates.length > 0) {
             for (const agg of filteredAggregates) {
-                // Doc ID format: {disease-slug}_{region-slug}_{period}_{date-key}
-                const parts = agg.id.split('_');
-                const dateKey = parts[parts.length - 1];
+                // Prefer explicit dateKey field; fall back to parsing doc ID
+                const dateKey = agg.dateKey || agg.id.split('_').pop();
                 if (!dateKey) continue;
 
                 const existing = byDate.get(dateKey);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 import type { User as FirebaseUser } from 'firebase/auth';
-import { onAuthChange, getUserProfile } from '../services/auth';
+import { onAuthChange, getUserProfile, subscribeToUserProfile } from '../services/auth';
 import type { User } from '../types';
 
 interface AuthContextType {
@@ -34,23 +34,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
 
     useEffect(() => {
-        const unsubscribe = onAuthChange(async (user) => {
+        let profileUnsub: (() => void) | null = null;
+
+        const authUnsub = onAuthChange((user) => {
             setFirebaseUser(user);
+            // Clean up previous profile listener
+            if (profileUnsub) {
+                profileUnsub();
+                profileUnsub = null;
+            }
             if (user) {
-                try {
-                    const profile = await getUserProfile(user.uid);
+                // Live listener — reacts to role/status changes in real-time
+                profileUnsub = subscribeToUserProfile(user.uid, (profile) => {
                     setUserProfile(profile);
-                } catch (err) {
-                    console.error('Failed to load user profile:', err);
-                    setUserProfile(null);
-                }
+                    setLoading(false);
+                });
             } else {
                 setUserProfile(null);
+                setLoading(false);
             }
-            setLoading(false);
         });
 
-        return unsubscribe;
+        return () => {
+            authUnsub();
+            if (profileUnsub) profileUnsub();
+        };
     }, []);
 
     return (

--- a/src/contexts/DashboardContext.tsx
+++ b/src/contexts/DashboardContext.tsx
@@ -139,39 +139,38 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         return unsubscribe;
     }, [queryRegion, refreshKey]);
 
-    // Subscribe to reports
+    // Subscribe to reports (server-side date filtering)
     useEffect(() => {
         setLoading(true);
-        const unsubscribe = subscribeToDashboardReports(queryRegion, (data) => {
-            setReports(data);
-            setLoading(false);
-            setLastUpdated(new Date());
-        });
+        const unsubscribe = subscribeToDashboardReports(
+            queryRegion,
+            filters.dateRange,
+            filters.disease !== 'all' ? filters.disease : undefined,
+            filters.status !== 'all' ? filters.status : undefined,
+            (data) => {
+                setReports(data);
+                setLoading(false);
+                setLastUpdated(new Date());
+            }
+        );
         return unsubscribe;
-    }, [queryRegion, refreshKey]);
+    }, [queryRegion, filters.dateRange, filters.disease, filters.status, refreshKey]);
 
-    // Client-side filtered reports
+    // Client-side filtered reports (date range is already server-side)
     const filteredReports = useMemo(() => {
         return reports.filter((report) => {
-            // Safely convert createdAt to a timestamp for comparison
-            const reportTime = report.createdAt instanceof Date
-                ? report.createdAt.getTime()
-                : new Date(report.createdAt).getTime();
-            if (isNaN(reportTime)) return true; // Include reports with invalid dates rather than hiding them
-            if (reportTime < filters.dateRange.start.getTime() || reportTime > filters.dateRange.end.getTime()) return false;
             if (filters.disease !== 'all' && report.disease !== filters.disease) return false;
             if (filters.status !== 'all' && report.status !== filters.status) return false;
             return true;
         });
-    }, [reports, filters.dateRange, filters.disease, filters.status]);
+    }, [reports, filters.disease, filters.status]);
 
     // Client-side filtered aggregates
     const filteredAggregates = useMemo(() => {
         return aggregates.filter((agg) => {
             if (filters.disease !== 'all' && agg.disease !== filters.disease) return false;
-            // Filter aggregates by date range using the date key from the document ID
-            const parts = agg.id.split('_');
-            const dateKey = parts[parts.length - 1];
+            // Use explicit dateKey field if available, fall back to parsing doc ID
+            const dateKey = agg.dateKey || agg.id.split('_').pop();
             if (dateKey) {
                 const aggDate = new Date(dateKey);
                 if (!isNaN(aggDate.getTime())) {

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -13,6 +13,13 @@ import {
 vi.mock('../../services/auth', () => ({
   onAuthChange: (callback: (user: unknown) => void) => mockOnAuthStateChanged({}, callback),
   getUserProfile: (uid: string) => mockGetDoc(uid),
+  subscribeToUserProfile: (uid: string, callback: (profile: unknown) => void) => {
+    mockGetDoc(uid).then(
+      (profile: unknown) => callback(profile),
+      () => callback(null)
+    );
+    return () => {};
+  },
 }));
 
 // Test component that uses the auth context

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -6,7 +6,7 @@ import {
     updateProfile,
     type User as FirebaseUser,
 } from 'firebase/auth';
-import { doc, setDoc, getDoc, serverTimestamp } from 'firebase/firestore';
+import { doc, setDoc, getDoc, onSnapshot, serverTimestamp, type Unsubscribe } from 'firebase/firestore';
 import { auth, db } from './firebase';
 import type { UserRole } from '../types';
 
@@ -65,6 +65,26 @@ export async function getUserProfile(uid: string) {
     const snap = await getDoc(doc(db, 'users', uid));
     if (!snap.exists()) return null;
     return { ...snap.data(), uid: snap.id } as import('../types').User;
+}
+
+/**
+ * Subscribe to real-time updates on a user's Firestore profile.
+ * Ensures role/status changes (e.g., rejection) take effect immediately.
+ */
+export function subscribeToUserProfile(
+    uid: string,
+    callback: (profile: import('../types').User | null) => void
+): Unsubscribe {
+    return onSnapshot(doc(db, 'users', uid), (snap) => {
+        if (!snap.exists()) {
+            callback(null);
+            return;
+        }
+        callback({ ...snap.data(), uid: snap.id } as import('../types').User);
+    }, (err) => {
+        console.error('Error subscribing to user profile:', err);
+        callback(null);
+    });
 }
 
 /**

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -3,7 +3,9 @@ import {
     query,
     where,
     orderBy,
+    limit,
     onSnapshot,
+    Timestamp,
     type Unsubscribe,
     type QueryConstraint,
 } from 'firebase/firestore';
@@ -92,13 +94,19 @@ export function subscribeToAlerts(
  */
 export function subscribeToDashboardReports(
     region: string | undefined,
+    dateRange: { start: Date; end: Date },
+    disease: string | undefined,
+    status: string | undefined,
     callback: (reports: Report[]) => void
 ): Unsubscribe {
     const constraints: QueryConstraint[] = [];
     if (region) {
         constraints.push(where('region', '==', region));
     }
+    constraints.push(where('createdAt', '>=', Timestamp.fromDate(dateRange.start)));
+    constraints.push(where('createdAt', '<=', Timestamp.fromDate(dateRange.end)));
     constraints.push(orderBy('createdAt', 'desc'));
+    constraints.push(limit(500));
 
     const q = query(
         collection(db, REPORTS_COLLECTION),

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,6 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth, connectAuthEmulator } from 'firebase/auth';
-import { getFirestore, connectFirestoreEmulator, enableIndexedDbPersistence } from 'firebase/firestore';
+import { initializeFirestore, persistentLocalCache, persistentMultipleTabManager, connectFirestoreEmulator } from 'firebase/firestore';
 
 /**
  * Firebase configuration.
@@ -21,7 +21,11 @@ const app = initializeApp(firebaseConfig);
 
 // Initialize services
 export const auth = getAuth(app);
-export const db = getFirestore(app);
+
+// Initialize Firestore with persistent local cache (replaces deprecated enableIndexedDbPersistence)
+export const db = initializeFirestore(app, {
+    localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() }),
+});
 
 // Connect to emulators in development mode (only if USE_EMULATORS env var is set)
 // To use emulators, run: VITE_USE_EMULATORS=true npm run dev
@@ -34,16 +38,5 @@ if (import.meta.env.DEV && import.meta.env.VITE_USE_EMULATORS === 'true' && wind
         console.log('Connected to Firebase emulators');
     }
 }
-
-// Enable offline persistence for Firestore
-enableIndexedDbPersistence(db).catch((err) => {
-    if (err.code === 'failed-precondition') {
-        // Multiple tabs open — persistence can only be enabled in one tab at a time
-        console.warn('Firestore persistence failed: multiple tabs open');
-    } else if (err.code === 'unimplemented') {
-        // The current browser does not support persistence
-        console.warn('Firestore persistence not supported in this browser');
-    }
-});
 
 export default app;

--- a/src/test/mocks/firebase.ts
+++ b/src/test/mocks/firebase.ts
@@ -127,6 +127,9 @@ vi.mock('firebase/auth', () => ({
 
 vi.mock('firebase/firestore', () => ({
   getFirestore: vi.fn(() => ({})),
+  initializeFirestore: vi.fn(() => ({})),
+  persistentLocalCache: vi.fn(() => ({})),
+  persistentMultipleTabManager: vi.fn(() => ({})),
   connectFirestoreEmulator: vi.fn(),
   doc: vi.fn(() => ({})),
   getDoc: (...args: unknown[]) => mockGetDoc(...args),
@@ -137,9 +140,10 @@ vi.mock('firebase/firestore', () => ({
   query: vi.fn(() => ({})),
   where: vi.fn(() => ({})),
   orderBy: vi.fn(() => ({})),
+  limit: vi.fn(() => ({})),
   onSnapshot: (...args: unknown[]) => mockOnSnapshot(...args),
   serverTimestamp: () => mockServerTimestamp(),
-  enableIndexedDbPersistence: vi.fn(() => Promise.resolve()),
+  Timestamp: { fromDate: vi.fn((d: Date) => d) },
 }));
 
 vi.mock('firebase/app', () => ({

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -46,6 +46,8 @@ export interface Aggregate {
     disease: string;
     region: string;
     period: AggregatePeriod;
+    /** Explicit date key for this bucket (e.g., "2026-03-12") */
+    dateKey: string;
     caseCount: number;
     verifiedCount: number;
     /** Total persons affected across all reports in this aggregate */


### PR DESCRIPTION
## Summary

- **Bound dashboard query**: Push date-range filters server-side with `limit(500)`, eliminating unbounded report fetches that degrade on low-end devices
- **Fix `alerts.threshold` bug**: Store the actual threshold count instead of the observed case count at alert creation
- **Fix aggregate time bucketing**: Use `report.createdAt` instead of Cloud Function execution time, so offline-synced reports are bucketed into the correct day/week
- **Exclude rejected reports from thresholds**: Add status filter to prevent false outbreak alerts from rejected reports
- **Add missing Firestore indexes**: Composite indexes for `alerts(status + createdAt)` and `reports(disease + region + status + createdAt)`
- **Live user profile listener**: Switch `AuthContext` from one-shot `getDoc` to `onSnapshot`, so role/status changes (e.g., rejection) take effect immediately
- **Explicit `dateKey` on aggregates**: Eliminates fragile document ID parsing that breaks on underscored disease/region names
- **Replace deprecated persistence API**: Migrate from `enableIndexedDbPersistence` to `initializeFirestore` with `persistentLocalCache`
- **Update schema docs**: Bring `docs/firestore-schema.md` in sync with actual types (`questions`, `thresholds`, `answers`, `auditLogs`, etc.)

## Test plan

- [x] All 111 existing tests pass (12 test files)
- [ ] Verify dashboard loads with date-bounded queries in emulator
- [ ] Confirm offline-submitted reports aggregate into correct date buckets
- [ ] Test that rejecting a user while logged in immediately reflects in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)