### PR TITLE
feat: multi-tier alert thresholds with geospatial clustering

### DIFF
--- a/functions/src/onReportWrite.ts
+++ b/functions/src/onReportWrite.ts
@@ -1,4 +1,4 @@
-import { onDocumentCreated } from 'firebase-functions/v2/firestore';
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
 import { initializeApp, getApps } from 'firebase-admin/app';
 import { getFirestore, FieldValue, Timestamp } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
@@ -11,15 +11,39 @@ const db = getFirestore();
 
 const SEVERITY_ORDER = ['low', 'medium', 'high', 'critical'] as const;
 
+type ThresholdType = 'immediate' | 'cluster';
+
 interface AlertThreshold {
     count: number;
     windowHours: number;
     severity: string;
     description: string;
+    type: ThresholdType;
+    requireVerified?: boolean;
+    proximityKm?: number;
+    requireDangerSigns?: boolean;
+    maxAgeMonths?: number;
 }
 
 /**
- * Create or update an alert for a disease+region combination.
+ * Haversine distance in km between two lat/lng points.
+ */
+function haversineKm(
+    lat1: number, lng1: number,
+    lat2: number, lng2: number
+): number {
+    const R = 6371;
+    const dLat = (lat2 - lat1) * Math.PI / 180;
+    const dLng = (lng2 - lng1) * Math.PI / 180;
+    const a =
+        Math.sin(dLat / 2) ** 2 +
+        Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+        Math.sin(dLng / 2) ** 2;
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
+ * Create or update an alert. Dedup logic differs for immediate vs cluster alerts.
  */
 async function createAlertIfNeeded(
     disease: string,
@@ -28,71 +52,110 @@ async function createAlertIfNeeded(
     thresholdCount: number,
     windowHours: number,
     severity: string,
-    immediateAlert: boolean
+    immediateAlert: boolean,
+    thresholdType: ThresholdType,
+    clusterCenter?: { lat: number; lng: number },
+    contributingReportIds?: string[]
 ): Promise<void> {
-    // Check for existing active alert for this disease+region
+    // Query existing active alerts for this disease+region
     const existingAlerts = await db
         .collection('alerts')
         .where('disease', '==', disease)
         .where('region', '==', region)
         .where('status', '==', 'active')
-        .limit(1)
         .get();
 
-    if (!existingAlerts.empty) {
-        // Update existing alert if new severity is higher
-        const existingAlert = existingAlerts.docs[0];
-        const existingData = existingAlert.data();
-        const newSeverityIdx = SEVERITY_ORDER.indexOf(severity as typeof SEVERITY_ORDER[number]);
-        const existingSeverityIdx = SEVERITY_ORDER.indexOf(existingData.severity);
-
-        await existingAlert.ref.update({
-            caseCount,
-            severity: newSeverityIdx > existingSeverityIdx ? severity : existingData.severity,
-            immediateAlert: existingData.immediateAlert || immediateAlert,
-        });
-
-        logger.info('Updated existing alert', { disease, region, caseCount, severity });
+    // For cluster alerts with clusterCenter, check proximity-based dedup
+    if (thresholdType === 'cluster' && clusterCenter) {
+        for (const doc of existingAlerts.docs) {
+            const data = doc.data();
+            if (data.thresholdType === 'cluster' && data.clusterCenter) {
+                const dist = haversineKm(
+                    clusterCenter.lat, clusterCenter.lng,
+                    data.clusterCenter.lat, data.clusterCenter.lng
+                );
+                if (dist <= 2) {
+                    // Update existing cluster alert if higher severity
+                    const newIdx = SEVERITY_ORDER.indexOf(severity as typeof SEVERITY_ORDER[number]);
+                    const existIdx = SEVERITY_ORDER.indexOf(data.severity);
+                    await doc.ref.update({
+                        caseCount,
+                        severity: newIdx > existIdx ? severity : data.severity,
+                        contributingReportIds: contributingReportIds || data.contributingReportIds,
+                    });
+                    logger.info('Updated existing cluster alert', { disease, region, caseCount });
+                    return;
+                }
+            }
+        }
     } else {
-        // Create new alert
-        await db.collection('alerts').add({
-            disease,
-            region,
-            caseCount,
-            threshold: thresholdCount,
-            windowHours,
-            severity,
-            status: 'active',
-            immediateAlert,
-            createdAt: FieldValue.serverTimestamp(),
-        });
-
-        logger.info('Created new alert', { disease, region, caseCount, severity, immediateAlert });
+        // Immediate alerts: dedup by disease+region (existing behavior)
+        if (!existingAlerts.empty) {
+            const existingAlert = existingAlerts.docs[0];
+            const existingData = existingAlert.data();
+            const newIdx = SEVERITY_ORDER.indexOf(severity as typeof SEVERITY_ORDER[number]);
+            const existIdx = SEVERITY_ORDER.indexOf(existingData.severity);
+            await existingAlert.ref.update({
+                caseCount,
+                severity: newIdx > existIdx ? severity : existingData.severity,
+                immediateAlert: existingData.immediateAlert || immediateAlert,
+            });
+            logger.info('Updated existing immediate alert', { disease, region, caseCount });
+            return;
+        }
     }
+
+    // Create new alert
+    const alertDoc: Record<string, unknown> = {
+        disease,
+        region,
+        caseCount,
+        threshold: thresholdCount,
+        windowHours,
+        severity,
+        status: 'active',
+        immediateAlert,
+        thresholdType,
+        createdAt: FieldValue.serverTimestamp(),
+    };
+    if (clusterCenter) alertDoc.clusterCenter = clusterCenter;
+    if (contributingReportIds) alertDoc.contributingReportIds = contributingReportIds;
+
+    await db.collection('alerts').add(alertDoc);
+    logger.info('Created new alert', { disease, region, severity, thresholdType });
 }
 
 /**
- * Triggered when a new report is created.
- * Checks case counts against disease thresholds and creates alerts.
+ * Triggered on any report write (create or update).
+ * - New report: evaluate immediate thresholds + cross-disease danger-signs alert
+ * - Status changed to verified: evaluate cluster thresholds
  */
-export const onReportWrite = onDocumentCreated(
+export const onReportWrite = onDocumentWritten(
     'reports/{reportId}',
     async (event) => {
-        const report = event.data?.data();
-        if (!report) return;
+        const before = event.data?.before?.data();
+        const after = event.data?.after?.data();
+        if (!after) return;
 
-        const { disease, region, isImmediateReport } = report;
         const reportId = event.params.reportId;
+        const { disease, region, hasDangerSigns, location } = after;
+        const isNewReport = !before;
+        const justVerified = before && before.status !== 'verified' && after.status === 'verified';
 
-        logger.info('Processing new report', { reportId, disease, region });
+        // Skip non-interesting updates
+        if (!isNewReport && !justVerified) return;
 
-        // 1. Handle immediate report flags (e.g., bloody diarrhea, measles rash)
-        if (isImmediateReport) {
-            logger.info('Immediate report flag detected', { reportId, disease });
-            await createAlertIfNeeded(disease, region, 1, 1, 168, 'critical', true);
+        logger.info('Processing report', { reportId, disease, region, isNewReport, justVerified });
+
+        // ── Cross-disease danger-signs alert (new reports only) ──
+        if (isNewReport && hasDangerSigns) {
+            logger.info('Danger signs detected, creating cross-disease alert', { reportId });
+            await createAlertIfNeeded(
+                'Danger Signs (Any Disease)', region, 1, 1, 0, 'critical', true, 'immediate'
+            );
         }
 
-        // 2. Look up case definition for threshold rules
+        // ── Look up case definition ──
         const caseDefSnapshot = await db
             .collection('caseDefinitions')
             .where('disease', '==', disease)
@@ -101,47 +164,91 @@ export const onReportWrite = onDocumentCreated(
             .get();
 
         if (caseDefSnapshot.empty) {
-            logger.warn('No active case definition found for disease', { disease });
+            logger.warn('No active case definition found', { disease });
             return;
         }
 
         const caseDef = caseDefSnapshot.docs[0].data();
         const thresholds: AlertThreshold[] = caseDef.thresholds || [];
 
-        // 3. Check each threshold rule
         for (const threshold of thresholds) {
-            const cutoffDate = new Date(Date.now() - threshold.windowHours * 60 * 60 * 1000);
-            const cutoffTimestamp = Timestamp.fromDate(cutoffDate);
+            // Gate: immediate thresholds on create, cluster thresholds on verify
+            if (threshold.type === 'immediate' && !isNewReport) continue;
+            if (threshold.type === 'cluster' && !justVerified) continue;
 
-            // Count non-rejected reports in the time window for this disease+region
-            const reportsInWindow = await db
-                .collection('reports')
+            // ── Immediate threshold ──
+            if (threshold.type === 'immediate') {
+                // Check if this report matches the threshold filters
+                if (threshold.requireDangerSigns && !after.hasDangerSigns) continue;
+                if (threshold.maxAgeMonths && (!after.patientAgeMonths || after.patientAgeMonths >= threshold.maxAgeMonths)) continue;
+
+                if (threshold.count === 1) {
+                    // Single-case immediate alert
+                    await createAlertIfNeeded(
+                        disease, region, 1, 1, threshold.windowHours,
+                        threshold.severity, true, 'immediate'
+                    );
+                } else {
+                    // Count-based immediate (rare, but supported)
+                    const cutoff = Timestamp.fromDate(new Date(Date.now() - threshold.windowHours * 3600000));
+                    const snap = await db.collection('reports')
+                        .where('disease', '==', disease)
+                        .where('region', '==', region)
+                        .where('status', 'in', ['pending', 'verified'])
+                        .where('createdAt', '>=', cutoff)
+                        .get();
+                    if (snap.size >= threshold.count) {
+                        await createAlertIfNeeded(
+                            disease, region, snap.size, threshold.count, threshold.windowHours,
+                            threshold.severity, false, 'immediate'
+                        );
+                    }
+                }
+                continue;
+            }
+
+            // ── Cluster threshold ──
+            const cutoff = Timestamp.fromDate(new Date(Date.now() - threshold.windowHours * 3600000));
+
+            // Query verified reports in the time window
+            const snap = await db.collection('reports')
                 .where('disease', '==', disease)
                 .where('region', '==', region)
-                .where('status', 'in', ['pending', 'verified'])
-                .where('createdAt', '>=', cutoffTimestamp)
+                .where('status', '==', 'verified')
+                .where('createdAt', '>=', cutoff)
                 .get();
 
-            const caseCount = reportsInWindow.size;
+            // In-memory filtering
+            const triggerLat = location?.lat;
+            const triggerLng = location?.lng;
+            if (!triggerLat || !triggerLng) continue;
 
-            if (caseCount >= threshold.count) {
-                logger.info('Threshold exceeded', {
-                    disease,
-                    region,
-                    caseCount,
-                    threshold: threshold.count,
-                    windowHours: threshold.windowHours,
-                    severity: threshold.severity,
-                });
+            const proximityKm = threshold.proximityKm || 2;
 
+            const matchingDocs = snap.docs.filter((doc) => {
+                const d = doc.data();
+                // Proximity filter
+                if (d.location?.lat && d.location?.lng) {
+                    if (haversineKm(triggerLat, triggerLng, d.location.lat, d.location.lng) > proximityKm) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+                // Danger signs filter
+                if (threshold.requireDangerSigns && !d.hasDangerSigns) return false;
+                // Age filter
+                if (threshold.maxAgeMonths && (!d.patientAgeMonths || d.patientAgeMonths >= threshold.maxAgeMonths)) return false;
+                return true;
+            });
+
+            if (matchingDocs.length >= threshold.count) {
+                const reportIds = matchingDocs.map((d) => d.id);
                 await createAlertIfNeeded(
-                    disease,
-                    region,
-                    caseCount,
-                    threshold.count,
-                    threshold.windowHours,
-                    threshold.severity,
-                    false
+                    disease, region, matchingDocs.length, threshold.count, threshold.windowHours,
+                    threshold.severity, false, 'cluster',
+                    { lat: triggerLat, lng: triggerLng },
+                    reportIds
                 );
             }
         }

--- a/scripts/seedCaseDefinitions.ts
+++ b/scripts/seedCaseDefinitions.ts
@@ -43,11 +43,18 @@ interface AssessmentQuestion {
     reclassifyTo?: string;
 }
 
+type ThresholdType = 'immediate' | 'cluster';
+
 interface AlertThreshold {
     count: number;
     windowHours: number;
     severity: AlertSeverity;
     description: string;
+    type: ThresholdType;
+    requireVerified?: boolean;
+    proximityKm?: number;
+    requireDangerSigns?: boolean;
+    maxAgeMonths?: number;
 }
 
 interface CaseDefinition {
@@ -152,7 +159,8 @@ const CASE_DEFINITIONS: Omit<CaseDefinition, 'id'>[] = [
             'Refer to seek clinical care if: any danger signs appear, diarrhea persists for more than 3 days, blood appears in stool, unable to keep ORS down due to vomiting.',
         active: true,
         thresholds: [
-            { count: 5, windowHours: 24, severity: 'high', description: '5+ cases in the same region or camp within 24 hours' },
+            { count: 10, windowHours: 24, severity: 'medium', description: '10+ verified cases within 2km in 24 hours', type: 'cluster', requireVerified: true, proximityKm: 2 },
+            { count: 5, windowHours: 24, severity: 'medium', description: '5+ verified under-5 cases within 2km in 24 hours', type: 'cluster', requireVerified: true, proximityKm: 2, maxAgeMonths: 60 },
         ],
         prioritySurveillance: false,
     },
@@ -220,7 +228,8 @@ const CASE_DEFINITIONS: Omit<CaseDefinition, 'id'>[] = [
             'Refer immediately to medical assessment. Offer ORS if available.',
         active: true,
         thresholds: [
-            { count: 1, windowHours: 168, severity: 'critical', description: 'Immediate alert — 1 confirmed case (potential cholera risk)' },
+            { count: 1, windowHours: 168, severity: 'critical', description: 'Immediate alert — 1 case', type: 'immediate' },
+            { count: 2, windowHours: 168, severity: 'high', description: '2+ verified cases within 2km in 1 week', type: 'cluster', requireVerified: true, proximityKm: 2 },
         ],
         prioritySurveillance: false,
     },
@@ -311,7 +320,7 @@ const CASE_DEFINITIONS: Omit<CaseDefinition, 'id'>[] = [
             'Refer immediately to medical assessment. Keep child upright to help breathing. Offer small sips of fluids if available.',
         active: true,
         thresholds: [
-            { count: 1, windowHours: 168, severity: 'critical', description: 'Immediate alert — 1 confirmed case' },
+            { count: 3, windowHours: 168, severity: 'high', description: '3+ verified cases with danger signs within 2km in 1 week', type: 'cluster', requireVerified: true, proximityKm: 2, requireDangerSigns: true },
         ],
         prioritySurveillance: false,
     },
@@ -400,7 +409,8 @@ const CASE_DEFINITIONS: Omit<CaseDefinition, 'id'>[] = [
             'Refer to seek care if: difficulty breathing, cannot drink, confusion or seizures, severe rash, any danger sign.',
         active: true,
         thresholds: [
-            { count: 1, windowHours: 168, severity: 'critical', description: 'Immediate alert — 1 suspected case' },
+            { count: 1, windowHours: 168, severity: 'critical', description: 'Immediate alert — 1 suspected case', type: 'immediate' },
+            { count: 2, windowHours: 168, severity: 'high', description: '2+ verified cases within 2km in 1 week', type: 'cluster', requireVerified: true, proximityKm: 2 },
         ],
         prioritySurveillance: true,
     },
@@ -477,7 +487,7 @@ const CASE_DEFINITIONS: Omit<CaseDefinition, 'id'>[] = [
             'Refer to clinical care if: blisters become infected, difficulty breathing, confusion or stiff neck, any danger sign.',
         active: true,
         thresholds: [
-            { count: 5, windowHours: 168, severity: 'medium', description: '5+ cases in region within 1 week' },
+            { count: 10, windowHours: 168, severity: 'medium', description: '10+ verified cases within 2km in 1 week', type: 'cluster', requireVerified: true, proximityKm: 2 },
         ],
         prioritySurveillance: false,
     },
@@ -563,7 +573,7 @@ const CASE_DEFINITIONS: Omit<CaseDefinition, 'id'>[] = [
             'Refer immediately to medical assessment. Encourage rest and fluids.',
         active: true,
         thresholds: [
-            { count: 2, windowHours: 168, severity: 'high', description: '1 above baseline or 2+ cases in one week (risk of hepatitis outbreak)' },
+            { count: 3, windowHours: 168, severity: 'high', description: '3+ verified cases within 2km in 1 week', type: 'cluster', requireVerified: true, proximityKm: 2 },
         ],
         prioritySurveillance: false,
     },
@@ -641,7 +651,7 @@ const CASE_DEFINITIONS: Omit<CaseDefinition, 'id'>[] = [
             'Refer if sores are not healing (>2 weeks). Cover sores with dressing (if available) and keep as clean as possible.',
         active: true,
         thresholds: [
-            { count: 5, windowHours: 168, severity: 'medium', description: '5+ cases in region within 1 week' },
+            { count: 5, windowHours: 168, severity: 'medium', description: '5+ verified cases within 2km in 1 week', type: 'cluster', requireVerified: true, proximityKm: 2 },
         ],
         prioritySurveillance: false,
     },
@@ -716,7 +726,7 @@ const CASE_DEFINITIONS: Omit<CaseDefinition, 'id'>[] = [
             'Refer immediately to medical assessment.',
         active: true,
         thresholds: [
-            { count: 1, windowHours: 168, severity: 'critical', description: 'Immediate alert — 1 case (polio surveillance)' },
+            { count: 1, windowHours: 168, severity: 'critical', description: 'Immediate alert — 1 case (polio surveillance)', type: 'immediate' },
         ],
         prioritySurveillance: true,
     },
@@ -837,8 +847,8 @@ const CASE_DEFINITIONS: Omit<CaseDefinition, 'id'>[] = [
             'Refer for medical assessment, especially infants under 6 months. Isolate from other children. Ensure adequate hydration.',
         active: true,
         thresholds: [
-            { count: 1, windowHours: 168, severity: 'high', description: '1 case in non-endemic area' },
-            { count: 5, windowHours: 168, severity: 'critical', description: '5+ cases in same region or camp within 1 week' },
+            { count: 1, windowHours: 168, severity: 'high', description: 'Immediate alert — 1 infant case', type: 'immediate', maxAgeMonths: 12 },
+            { count: 5, windowHours: 168, severity: 'high', description: '5+ verified cases within 2km in 1 week', type: 'cluster', requireVerified: true, proximityKm: 2 },
         ],
         prioritySurveillance: true,
     },
@@ -957,7 +967,8 @@ const CASE_DEFINITIONS: Omit<CaseDefinition, 'id'>[] = [
             'Refer immediately to medical assessment. Isolate patient. This is a medical emergency if airway is compromised.',
         active: true,
         thresholds: [
-            { count: 1, windowHours: 168, severity: 'critical', description: 'Immediate alert — 1 suspected case' },
+            { count: 1, windowHours: 168, severity: 'critical', description: 'Immediate alert — 1 suspected case', type: 'immediate' },
+            { count: 2, windowHours: 168, severity: 'high', description: '2+ verified cases within 2km in 1 week', type: 'cluster', requireVerified: true, proximityKm: 2 },
         ],
         prioritySurveillance: true,
     },

--- a/scripts/seedReports.ts
+++ b/scripts/seedReports.ts
@@ -257,6 +257,7 @@ interface SeedReport {
     hasDangerSigns: boolean;
     isImmediateReport: boolean;
     personsCount: number;
+    patientAgeMonths?: number;
     createdAt: Date;
     verifiedBy?: string;
     verifiedAt?: Date;
@@ -304,6 +305,7 @@ function generateReports(count: number): SeedReport[] {
             hasDangerSigns,
             isImmediateReport,
             personsCount: Math.random() > 0.7 ? randomInt(2, 8) : 1,
+            patientAgeMonths: Math.random() > 0.3 ? randomInt(1, 720) : undefined,
             createdAt,
         };
 
@@ -405,6 +407,7 @@ async function seedReports(db: Firestore): Promise<void> {
         };
 
         if (report.temp !== undefined) firestoreDoc.temp = report.temp;
+        if (report.patientAgeMonths !== undefined) firestoreDoc.patientAgeMonths = report.patientAgeMonths;
         if (report.verifiedBy) firestoreDoc.verifiedBy = report.verifiedBy;
         if (report.verifiedAt) firestoreDoc.verifiedAt = Timestamp.fromDate(report.verifiedAt);
         if (report.verificationNotes) firestoreDoc.verificationNotes = report.verificationNotes;

--- a/src/components/charts/AlertsPanel.tsx
+++ b/src/components/charts/AlertsPanel.tsx
@@ -68,6 +68,9 @@ export default function AlertsPanel() {
                                                 color={SEVERITY_COLOR[alert.severity]}
                                                 variant={alert.severity === 'critical' ? 'filled' : 'outlined'}
                                             />
+                                            {alert.thresholdType === 'cluster' && (
+                                                <Chip label="Cluster" size="small" variant="outlined" />
+                                            )}
                                         </Box>
                                     }
                                     secondary={

--- a/src/components/forms/ReportForm.tsx
+++ b/src/components/forms/ReportForm.tsx
@@ -56,6 +56,8 @@ export default function ReportForm({ onSuccess }: { onSuccess?: () => void }) {
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState('');
     const [personsCount, setPersonsCount] = useState(1);
+    const [ageYears, setAgeYears] = useState('');
+    const [ageMonths, setAgeMonths] = useState('');
     const [reclassifiedFrom, setReclassifiedFrom] = useState<string | null>(null);
     const [selectedRegion, setSelectedRegion] = useState(userProfile?.region || '');
     const [geoPermission, setGeoPermission] = useState<'granted' | 'prompt' | 'denied' | 'unsupported'>('prompt');
@@ -73,6 +75,8 @@ export default function ReportForm({ onSuccess }: { onSuccess?: () => void }) {
             setAnswers({});
             setSelectedDangerSigns([]);
             setPersonsCount(1);
+            setAgeYears('');
+            setAgeMonths('');
             setReclassifiedFrom(null);
         }
     };
@@ -169,6 +173,10 @@ export default function ReportForm({ onSuccess }: { onSuccess?: () => void }) {
             (q) => q.isImmediateReport && answers[q.id]?.answer === true
         );
 
+        const patientAgeMonths = (ageYears || ageMonths)
+            ? (parseInt(ageYears) || 0) * 12 + (parseInt(ageMonths) || 0)
+            : undefined;
+
         setSubmitting(true);
         setError('');
 
@@ -186,6 +194,7 @@ export default function ReportForm({ onSuccess }: { onSuccess?: () => void }) {
                 hasDangerSigns,
                 isImmediateReport,
                 personsCount,
+                patientAgeMonths,
                 reclassifiedFrom: reclassifiedFrom || undefined,
             });
             onSuccess?.();
@@ -312,6 +321,26 @@ export default function ReportForm({ onSuccess }: { onSuccess?: () => void }) {
                                 sx={{ mt: 2 }}
                                 helperText="How many people are affected in this report (minimum 1)"
                             />
+                            <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+                                <TextField
+                                    label="Patient Age (Years)"
+                                    type="number"
+                                    value={ageYears}
+                                    onChange={(e) => setAgeYears(e.target.value)}
+                                    inputProps={{ min: 0, max: 120 }}
+                                    sx={{ flex: 1 }}
+                                    helperText="Optional"
+                                />
+                                <TextField
+                                    label="Months"
+                                    type="number"
+                                    value={ageMonths}
+                                    onChange={(e) => setAgeMonths(e.target.value)}
+                                    inputProps={{ min: 0, max: 11 }}
+                                    sx={{ flex: 1 }}
+                                    helperText="Additional months"
+                                />
+                            </Box>
                         </>
                     )}
                 </Box>

--- a/src/services/reports.ts
+++ b/src/services/reports.ts
@@ -31,6 +31,7 @@ export async function createReport(data: {
     hasDangerSigns: boolean;
     isImmediateReport: boolean;
     personsCount: number;
+    patientAgeMonths?: number;
     reclassifiedFrom?: string;
 }): Promise<string> {
     // Strip undefined values — Firestore rejects them

--- a/src/types/alert.ts
+++ b/src/types/alert.ts
@@ -31,6 +31,12 @@ export interface Alert {
     status: AlertStatus;
     /** Whether this was triggered by an immediate-report flag */
     immediateAlert: boolean;
+    /** Center point of the geographic cluster (cluster alerts only) */
+    clusterCenter?: { lat: number; lng: number };
+    /** Whether this alert was from an immediate or cluster threshold */
+    thresholdType?: 'immediate' | 'cluster';
+    /** IDs of reports that contributed to this cluster alert */
+    contributingReportIds?: string[];
     createdAt: Date;
     resolvedAt?: Date;
 }

--- a/src/types/caseDefinition.ts
+++ b/src/types/caseDefinition.ts
@@ -40,6 +40,11 @@ export interface AssessmentQuestion {
 }
 
 /**
+ * Whether a threshold fires on report creation or after verification clustering.
+ */
+export type ThresholdType = 'immediate' | 'cluster';
+
+/**
  * Alert threshold rule for a disease.
  * Supports time-windowed thresholds per the GH partner's specifications.
  */
@@ -52,6 +57,16 @@ export interface AlertThreshold {
     severity: AlertSeverity;
     /** Description for display (e.g., "5+ cases in same region within 24 hours") */
     description: string;
+    /** Whether this threshold fires on creation (immediate) or verification (cluster) */
+    type: ThresholdType;
+    /** Cluster: only count verified reports */
+    requireVerified?: boolean;
+    /** Cluster: geo-distance in km instead of region-wide */
+    proximityKm?: number;
+    /** Filter to hasDangerSigns === true */
+    requireDangerSigns?: boolean;
+    /** Filter to patientAgeMonths < this value */
+    maxAgeMonths?: number;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
 export type { User, UserRole, UserStatus } from './user';
 export type { Report, ReportStatus, ReportLocation, QuestionAnswer } from './report';
-export type { CaseDefinition, AssessmentQuestion, AlertThreshold } from './caseDefinition';
+export type { CaseDefinition, AssessmentQuestion, AlertThreshold, ThresholdType } from './caseDefinition';
 export type { Alert, AlertSeverity, AlertStatus, Aggregate, AggregatePeriod } from './alert';

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -63,6 +63,8 @@ export interface Report {
     isImmediateReport: boolean;
     /** Number of persons affected in this report (minimum 1) */
     personsCount: number;
+    /** Patient age in months (optional, new reports only) */
+    patientAgeMonths?: number;
     /** If reclassification was triggered, the original disease */
     reclassifiedFrom?: string;
     createdAt: Date;


### PR DESCRIPTION
## Summary
- **Cloud function rewrite**: Switch `onReportWrite` from `onDocumentCreated` to `onDocumentWritten` with two-tier threshold evaluation — immediate thresholds fire on report creation, cluster thresholds fire when a report is verified
- **Geospatial proximity**: Haversine distance filtering (≤2km) replaces simple region-wide counting for cluster alerts, with proximity-based dedup
- **New filters**: Patient age (`maxAgeMonths`), danger signs (`requireDangerSigns`), and verified-only (`requireVerified`) filters on thresholds
- **Cross-disease danger-signs alert**: Any new report with `hasDangerSigns` triggers a critical "Danger Signs (Any Disease)" alert
- **UI changes**: Patient age input (years + months) on the report form; "Cluster" badge on cluster alerts in the alerts panel
- **Seed data**: All 10 diseases updated with typed immediate/cluster thresholds per spec; seed reports include random `patientAgeMonths`

## Test plan
- [ ] Unit test Haversine function with known distances
- [ ] Emulator: create report with `hasDangerSigns: true` → verify cross-disease critical alert
- [ ] Emulator: create + verify 2 measles reports within 2km → verify cluster alert created
- [ ] Emulator: create + verify 2 measles reports >2km apart → verify NO cluster alert
- [ ] Emulator: create pertussis report with `patientAgeMonths: 6` → verify infant immediate alert
- [ ] Emulator: create 5 pending AWD reports → verify cluster threshold does NOT fire
- [ ] Emulator: verify a report bringing cluster count to threshold → alert created on status change
- [ ] Manual: submit report with age field through UI, verify it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)