### PR TITLE
fix: convert Firestore Timestamps to JS Dates in user profile

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -67,7 +67,13 @@ export async function signOut(): Promise<void> {
 export async function getUserProfile(uid: string) {
     const snap = await getDoc(doc(db, 'users', uid));
     if (!snap.exists()) return null;
-    return { ...snap.data(), uid: snap.id } as import('../types').User;
+    const data = snap.data();
+    return {
+        ...data,
+        uid: snap.id,
+        createdAt: data.createdAt?.toDate() || new Date(),
+        updatedAt: data.updatedAt?.toDate() || new Date(),
+    } as import('../types').User;
 }
 
 /**
@@ -83,7 +89,13 @@ export function subscribeToUserProfile(
             callback(null);
             return;
         }
-        callback({ ...snap.data(), uid: snap.id } as import('../types').User);
+        const data = snap.data();
+        callback({
+            ...data,
+            uid: snap.id,
+            createdAt: data.createdAt?.toDate() || new Date(),
+            updatedAt: data.updatedAt?.toDate() || new Date(),
+        } as import('../types').User);
     }, (err) => {
         console.error('Error subscribing to user profile:', err);
         callback(null);


### PR DESCRIPTION
## Summary
- Fixes `createdAt.toLocaleDateString is not a function` crash on the Profile page
- `getUserProfile` and `subscribeToUserProfile` in `src/services/auth.ts` were spreading raw Firestore data without converting Timestamp fields to JS Dates
- Now calls `.toDate()` on `createdAt` and `updatedAt` before returning, consistent with other subscription functions in the codebase

## Test plan
- [ ] Navigate to Profile page — no crash, "Active since" displays correctly
- [ ] Verify other pages using `userProfile` (dashboard, reports) still work
- [ ] Test with a new user whose `createdAt` may not yet exist (fallback to `new Date()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)