### PR TITLE
feat: add human-readable case IDs to reports

### DIFF
--- a/src/pages/ReportFormPage.tsx
+++ b/src/pages/ReportFormPage.tsx
@@ -100,6 +100,7 @@ export function ReportFormPage() {
         region: userProfile?.region || 'Rafah',
     });
     const [submitted, setSubmitted] = useState(false);
+    const [submittedCaseId, setSubmittedCaseId] = useState<string | null>(null);
     const [submitLoading, setSubmitLoading] = useState(false);
 
     const filteredDiseases = diseases.filter((d) =>
@@ -148,7 +149,7 @@ export function ReportFormPage() {
                 ? parseFloat(answers[tempQuestion.id].value!)
                 : undefined;
 
-            await createReport({
+            const { caseId } = await createReport({
                 disease: selectedDisease.name,
                 answers: questionAnswers,
                 symptoms: getDetectedSymptoms(),
@@ -166,6 +167,7 @@ export function ReportFormPage() {
                 isImmediateReport: hasImmediateFlag,
                 personsCount: parseInt(personsAffected) || 1,
             });
+            setSubmittedCaseId(caseId);
             setSubmitted(true);
         } catch (err) {
             console.error('Failed to submit report:', err);
@@ -183,11 +185,14 @@ export function ReportFormPage() {
                             <CheckCircle className="h-10 w-10 text-green-600" />
                         </div>
                         <h2 className="text-2xl text-gray-900 mb-2">Report Submitted Successfully</h2>
+                        {submittedCaseId && (
+                            <p className="text-lg font-mono text-teal-700 mb-2">Case reference: {submittedCaseId}</p>
+                        )}
                         <p className="text-gray-600 mb-6">Your disease report has been submitted and will sync when online.</p>
                         <div className="flex gap-3 justify-center">
                             <Button variant="outline" onClick={() => navigate('/reports')}>View Reports</Button>
                             <Button className="bg-blue-600 hover:bg-blue-700" onClick={() => {
-                                setStep(1); setSelectedDisease(null); setAnswers({}); setPersonsAffected('1'); setSubmitted(false);
+                                setStep(1); setSelectedDisease(null); setAnswers({}); setPersonsAffected('1'); setSubmittedCaseId(null); setSubmitted(false);
                             }}>Submit Another</Button>
                         </div>
                     </CardContent>

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -85,6 +85,9 @@ export function ReportsPage() {
                 <div className="space-y-3">
                     <div className="flex items-start justify-between">
                         <div className="flex-1">
+                            {report.caseId && (
+                                <span className="text-xs font-mono text-gray-500 mb-1">{report.caseId}</span>
+                            )}
                             <div className="flex items-center gap-2 mb-2">
                                 <h3 className="font-medium text-gray-900">{report.disease}</h3>
                                 {report.isImmediateReport && <Badge className="bg-red-600 text-white">IMMEDIATE</Badge>}

--- a/src/services/__tests__/reports.test.ts
+++ b/src/services/__tests__/reports.test.ts
@@ -40,7 +40,7 @@ describe('Reports Service', () => {
       const result = await createReport(reportData);
 
       expect(mockAddDoc).toHaveBeenCalled();
-      expect(result).toBe('new-report-id');
+      expect(result).toEqual({ id: 'new-report-id', caseId: expect.any(String) });
     });
 
     it('includes all required fields in report', async () => {

--- a/src/services/reports.ts
+++ b/src/services/reports.ts
@@ -15,6 +15,18 @@ import type { Report, ReportLocation, QuestionAnswer } from '../types';
 
 const REPORTS_COLLECTION = 'reports';
 
+const CASE_ID_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+function generateCaseId(): string {
+    const now = new Date();
+    const date = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`;
+    let suffix = '';
+    for (let i = 0; i < 4; i++) {
+        suffix += CASE_ID_CHARS[Math.floor(Math.random() * CASE_ID_CHARS.length)];
+    }
+    return `SC-${date}-${suffix}`;
+}
+
 /**
  * Create a new case report.
  */
@@ -33,17 +45,19 @@ export async function createReport(data: {
     personsCount: number;
     patientAgeMonths?: number;
     reclassifiedFrom?: string;
-}): Promise<string> {
+}): Promise<{ id: string; caseId: string }> {
+    const caseId = generateCaseId();
     // Strip undefined values — Firestore rejects them
     const cleanData = Object.fromEntries(
         Object.entries(data).filter(([, v]) => v !== undefined)
     );
     const docRef = await addDoc(collection(db, REPORTS_COLLECTION), {
         ...cleanData,
+        caseId,
         status: 'pending',
         createdAt: serverTimestamp(),
     });
-    return docRef.id;
+    return { id: docRef.id, caseId };
 }
 
 /**

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -33,6 +33,8 @@ export interface QuestionAnswer {
  */
 export interface Report {
     id: string;
+    /** Human-readable case reference (e.g. SC-20260323-A1B2) */
+    caseId?: string;
     /** Disease identifier — references caseDefinitions */
     disease: string;
     /** Structured answers to assessment questions */


### PR DESCRIPTION
## Summary
- Generates client-side case references (e.g. `SC-20260323-A1B2`) when creating reports and stores them in Firestore
- Displays the case ID on the report submission success screen and in the reports list
- Makes `caseId` optional in the `Report` type to handle existing documents without the field
- Updates `createReport` return type and corresponding test to reflect the new `{ id, caseId }` shape

## Test plan
- [ ] Submit a new report and verify a case reference is displayed on the success screen
- [ ] Check the reports list shows case IDs for new reports and handles old reports without one
- [ ] Run `npm test` to confirm the updated test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)