### PR TITLE
fix: ensure all reports have case IDs

### DIFF
--- a/scripts/seedReports.ts
+++ b/scripts/seedReports.ts
@@ -100,6 +100,18 @@ function weightedPick(items: { disease: string; weight: number }[]): string {
     return items[items.length - 1].disease;
 }
 
+const CASE_ID_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+/** Generate a human-readable case ID for a given date (same format as src/services/reports.ts) */
+function generateCaseId(date: Date): string {
+    const dateStr = `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}`;
+    let suffix = '';
+    for (let i = 0; i < 4; i++) {
+        suffix += CASE_ID_CHARS[Math.floor(Math.random() * CASE_ID_CHARS.length)];
+    }
+    return `SC-${dateStr}-${suffix}`;
+}
+
 /** Generate a random date within the last N days */
 function randomDate(daysBack: number): Date {
     const now = Date.now();
@@ -244,6 +256,7 @@ function generateDangerSigns(disease: string): { dangerSigns: string[]; hasDange
 // ─── Report Generation ───
 
 interface SeedReport {
+    caseId: string;
     disease: string;
     answers: { questionId: string; questionText: string; answer: boolean; numericValue?: number }[];
     symptoms: string[];
@@ -288,6 +301,7 @@ function generateReports(count: number): SeedReport[] {
         else status = 'rejected';
 
         const report: SeedReport = {
+            caseId: generateCaseId(createdAt),
             disease,
             answers,
             symptoms,
@@ -391,6 +405,7 @@ async function seedReports(db: Firestore): Promise<void> {
 
         // Build the Firestore document
         const firestoreDoc: Record<string, unknown> = {
+            caseId: report.caseId,
             disease: report.disease,
             answers: report.answers,
             symptoms: report.symptoms,

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -85,9 +85,7 @@ export function ReportsPage() {
                 <div className="space-y-3">
                     <div className="flex items-start justify-between">
                         <div className="flex-1">
-                            {report.caseId && (
-                                <span className="text-xs font-mono text-gray-500 mb-1">{report.caseId}</span>
-                            )}
+                            <span className="text-xs font-mono text-gray-500 mb-1">{report.caseId || report.id.slice(0, 8).toUpperCase()}</span>
                             <div className="flex items-center gap-2 mb-2">
                                 <h3 className="font-medium text-gray-900">{report.disease}</h3>
                                 {report.isImmediateReport && <Badge className="bg-red-600 text-white">IMMEDIATE</Badge>}


### PR DESCRIPTION
## Summary
- Add `caseId` generation (`SC-YYYYMMDD-XXXX`) to the seed script so all 150 seeded reports get human-readable case IDs
- Show a fallback identifier (truncated Firestore doc ID) in ReportsPage for any pre-existing reports that lack a `caseId`

## Test plan
- [ ] Run `npm run build` — no type errors
- [ ] Run `npm test` — no new test failures
- [ ] Seed reports and verify each has a `caseId` field
- [ ] Confirm ReportsPage displays a case reference for reports with and without `caseId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)