### PR TITLE
fix: prevent infinite login spinner when profile subscription fails

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -36,19 +36,43 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     useEffect(() => {
         let profileUnsub: (() => void) | null = null;
 
+        let timeout: ReturnType<typeof setTimeout> | null = null;
+
         const authUnsub = onAuthChange((user) => {
             setFirebaseUser(user);
-            // Clean up previous profile listener
+            // Clean up previous profile listener and timeout
             if (profileUnsub) {
                 profileUnsub();
                 profileUnsub = null;
             }
+            if (timeout) {
+                clearTimeout(timeout);
+                timeout = null;
+            }
             if (user) {
                 // Live listener — reacts to role/status changes in real-time
-                profileUnsub = subscribeToUserProfile(user.uid, (profile) => {
-                    setUserProfile(profile);
+                try {
+                    profileUnsub = subscribeToUserProfile(user.uid, (profile) => {
+                        if (timeout) {
+                            clearTimeout(timeout);
+                            timeout = null;
+                        }
+                        setUserProfile(profile);
+                        setLoading(false);
+                    });
+                } catch (err) {
+                    console.error('Failed to subscribe to user profile:', err);
+                    setUserProfile(null);
                     setLoading(false);
-                });
+                    return;
+                }
+                // Fallback: if profile never loads, stop spinning after 10s
+                timeout = setTimeout(() => {
+                    setLoading((prev) => {
+                        if (prev) console.warn('Auth loading timed out — forcing completion');
+                        return false;
+                    });
+                }, 10_000);
             } else {
                 setUserProfile(null);
                 setLoading(false);
@@ -58,6 +82,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return () => {
             authUnsub();
             if (profileUnsub) profileUnsub();
+            if (timeout) clearTimeout(timeout);
         };
     }, []);
 


### PR DESCRIPTION
## Summary
- Wraps `subscribeToUserProfile` in a try-catch so a synchronous throw sets `loading = false` instead of leaving the spinner forever
- Adds a 10-second timeout fallback so if Firestore's `onSnapshot` never fires (e.g., network issues with no cache), loading still resolves
- The existing "Unable to Load Profile" error screen (from #46) handles the `userProfile = null` case once loading completes

## Test plan
- [ ] Log in as supervisor — dashboard loads without infinite spinner
- [ ] Simulate Firestore failure (disconnect network after login) — error screen appears after ~10s
- [ ] `npx vitest run` — all 70 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)