### PR TITLE
feat: show disease reports in alert details with view report button

### DIFF
--- a/src/components/reports/AlertReportsList.tsx
+++ b/src/components/reports/AlertReportsList.tsx
@@ -1,0 +1,107 @@
+import { useState, useEffect } from 'react';
+import { Eye } from 'lucide-react';
+import { Button } from '../ui/button';
+import { Badge } from '../ui/badge';
+import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '../ui/table';
+import { subscribeToReportsByDisease } from '../../services/reports';
+import { ReportDetailDialog } from './ReportDetailDialog';
+import type { Alert, Report } from '../../types';
+
+interface AlertReportsListProps {
+    alert: Alert;
+}
+
+export function AlertReportsList({ alert }: AlertReportsListProps) {
+    const [reports, setReports] = useState<Report[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [selectedReport, setSelectedReport] = useState<Report | null>(null);
+
+    useEffect(() => {
+        setLoading(true);
+        const unsub = subscribeToReportsByDisease(alert.disease, alert.region, (data) => {
+            setReports(data);
+            setLoading(false);
+        });
+        return unsub;
+    }, [alert.disease, alert.region]);
+
+    if (loading) {
+        return (
+            <div className="mt-3 bg-white rounded-lg border border-gray-200 p-4 text-center text-sm text-gray-500">
+                Loading reports...
+            </div>
+        );
+    }
+
+    if (reports.length === 0) {
+        return (
+            <div className="mt-3 bg-white rounded-lg border border-gray-200 p-4 text-center text-sm text-gray-500">
+                No reports found for {alert.disease}
+            </div>
+        );
+    }
+
+    return (
+        <div className="mt-3 bg-white rounded-lg border border-gray-200 overflow-hidden">
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Case ID</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Reporter</TableHead>
+                        <TableHead>Location</TableHead>
+                        <TableHead>Date</TableHead>
+                        <TableHead className="text-right">Action</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {reports.map((report) => (
+                        <TableRow key={report.id}>
+                            <TableCell className="font-mono text-xs">
+                                {report.caseId || report.id.slice(0, 8).toUpperCase()}
+                            </TableCell>
+                            <TableCell>
+                                <Badge
+                                    variant="outline"
+                                    className={
+                                        report.status === 'verified'
+                                            ? 'border-green-500 text-green-700'
+                                            : report.status === 'rejected'
+                                              ? 'border-red-500 text-red-700'
+                                              : 'border-orange-500 text-orange-700'
+                                    }
+                                >
+                                    {report.status.charAt(0).toUpperCase() + report.status.slice(1)}
+                                </Badge>
+                            </TableCell>
+                            <TableCell>{report.reporterName || 'Unknown'}</TableCell>
+                            <TableCell>
+                                {report.location?.name ||
+                                    `${report.location?.lat?.toFixed(4)}, ${report.location?.lng?.toFixed(4)}`}
+                            </TableCell>
+                            <TableCell className="text-gray-600">
+                                {report.createdAt.toLocaleDateString()}
+                            </TableCell>
+                            <TableCell className="text-right">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setSelectedReport(report)}
+                                >
+                                    <Eye className="h-4 w-4 mr-1" />
+                                    View Report
+                                </Button>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+
+            <ReportDetailDialog
+                report={selectedReport}
+                open={selectedReport !== null}
+                onClose={() => setSelectedReport(null)}
+            />
+        </div>
+    );
+}

--- a/src/components/reports/ReportDetailDialog.tsx
+++ b/src/components/reports/ReportDetailDialog.tsx
@@ -1,0 +1,122 @@
+import { AlertTriangle, MapPin, Thermometer, Users, Clock } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
+import { Badge } from '../ui/badge';
+import type { Report } from '../../types';
+
+interface ReportDetailDialogProps {
+    report: Report | null;
+    open: boolean;
+    onClose: () => void;
+}
+
+export function ReportDetailDialog({ report, open, onClose }: ReportDetailDialogProps) {
+    if (!report) return null;
+
+    return (
+        <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+            <DialogContent className="max-w-lg">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <span className="font-mono text-sm text-gray-500">
+                            {report.caseId || report.id.slice(0, 8).toUpperCase()}
+                        </span>
+                        <span>{report.disease}</span>
+                        {report.isImmediateReport && (
+                            <Badge className="bg-red-600 text-white">IMMEDIATE</Badge>
+                        )}
+                    </DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-4">
+                    {/* Status */}
+                    <Badge
+                        variant="outline"
+                        className={
+                            report.status === 'verified'
+                                ? 'border-green-500 text-green-700'
+                                : report.status === 'rejected'
+                                  ? 'border-red-500 text-red-700'
+                                  : 'border-orange-500 text-orange-700'
+                        }
+                    >
+                        {report.status.charAt(0).toUpperCase() + report.status.slice(1)}
+                    </Badge>
+
+                    {/* Reporter & time */}
+                    <div className="flex items-center gap-4 text-sm text-gray-600">
+                        <span className="flex items-center gap-1">
+                            <Users className="h-4 w-4" />
+                            {report.reporterName || 'Unknown'}
+                        </span>
+                        <span className="flex items-center gap-1">
+                            <Clock className="h-4 w-4" />
+                            {report.createdAt.toLocaleString()}
+                        </span>
+                    </div>
+
+                    {/* Location & vitals */}
+                    <div className="flex items-center gap-4 text-sm text-gray-600">
+                        <span className="flex items-center gap-1">
+                            <MapPin className="h-4 w-4" />
+                            {report.location?.name ||
+                                `${report.location?.lat?.toFixed(4)}, ${report.location?.lng?.toFixed(4)}`}
+                        </span>
+                        {report.personsCount > 1 && (
+                            <Badge variant="secondary">{report.personsCount} persons affected</Badge>
+                        )}
+                        {report.temp && (
+                            <span className="flex items-center gap-1">
+                                <Thermometer className="h-4 w-4" />
+                                {report.temp}°C
+                            </span>
+                        )}
+                    </div>
+
+                    {/* Symptoms */}
+                    {report.symptoms && report.symptoms.length > 0 && (
+                        <div>
+                            <p className="text-xs font-medium text-gray-500 mb-1">Symptoms</p>
+                            <div className="flex flex-wrap gap-1">
+                                {report.symptoms.map((symptom, idx) => (
+                                    <Badge key={idx} variant="secondary" className="text-xs">
+                                        {symptom}
+                                    </Badge>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Danger signs */}
+                    {report.dangerSigns && report.dangerSigns.length > 0 && (
+                        <div>
+                            <p className="text-xs font-medium text-gray-500 mb-1">Danger Signs</p>
+                            <div className="flex flex-wrap gap-1">
+                                {report.dangerSigns.map((sign, idx) => (
+                                    <Badge
+                                        key={idx}
+                                        className="bg-red-100 text-red-700 hover:bg-red-100 text-xs"
+                                    >
+                                        <AlertTriangle className="h-3 w-3 mr-1" />
+                                        {sign}
+                                    </Badge>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Verification notes */}
+                    {report.verificationNotes && (
+                        <div className="p-3 bg-gray-50 rounded-lg">
+                            <p className="text-sm text-gray-700 mb-1">{report.verificationNotes}</p>
+                            <p className="text-xs text-gray-500">
+                                {report.status === 'verified' ? 'Verified' : 'Rejected'} by{' '}
+                                {report.verifiedBy}
+                                {report.verifiedAt && ` on ${report.verifiedAt.toLocaleString()}`}
+                            </p>
+                        </div>
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -8,6 +8,7 @@ import { subscribeToAlerts } from '../services/dashboard';
 import type { Alert } from '../types';
 import ReportMap from '../components/maps/ReportMap';
 import { DashboardProvider, useDashboard } from '../contexts/DashboardContext';
+import { AlertReportsList } from '../components/reports/AlertReportsList';
 import { getDiseaseColor } from '../components/maps/DiseaseMarker';
 
 function formatTimeAgo(date: Date): string {
@@ -234,22 +235,7 @@ export function DashboardPage() {
                                             </Button>
                                         </div>
                                         {expandedAlerts.includes(alert.id) && (
-                                            <div className="mt-3 bg-white rounded-lg border border-gray-200 p-4">
-                                                <div className="space-y-2 text-sm">
-                                                    <div className="flex justify-between">
-                                                        <span className="text-gray-600">Region:</span>
-                                                        <span className="font-medium">{alert.region}</span>
-                                                    </div>
-                                                    <div className="flex justify-between">
-                                                        <span className="text-gray-600">Window:</span>
-                                                        <span className="font-medium">{alert.windowHours}h</span>
-                                                    </div>
-                                                    <div className="flex justify-between">
-                                                        <span className="text-gray-600">Created:</span>
-                                                        <span className="font-medium">{alert.createdAt.toLocaleString()}</span>
-                                                    </div>
-                                                </div>
-                                            </div>
+                                            <AlertReportsList alert={alert} />
                                         )}
                                     </div>
                                 ))

--- a/src/services/reports.ts
+++ b/src/services/reports.ts
@@ -6,9 +6,11 @@ import {
     query,
     where,
     orderBy,
+    limit,
     onSnapshot,
     serverTimestamp,
     type Unsubscribe,
+    type QueryConstraint,
 } from 'firebase/firestore';
 import { db } from './firebase';
 import type { Report, ReportLocation, QuestionAnswer } from '../types';
@@ -122,6 +124,39 @@ export async function verifyReport(
         verifiedBy: verifierId,
         verificationNotes: notes || null,
         verifiedAt: serverTimestamp(),
+    });
+}
+
+/**
+ * Subscribe to reports for a specific disease (dashboard drill-down).
+ */
+export function subscribeToReportsByDisease(
+    disease: string,
+    region: string | undefined,
+    callback: (reports: Report[]) => void
+): Unsubscribe {
+    const constraints: QueryConstraint[] = [
+        where('disease', '==', disease),
+    ];
+    if (region) {
+        constraints.push(where('region', '==', region));
+    }
+    constraints.push(orderBy('createdAt', 'desc'));
+    constraints.push(limit(50));
+
+    const q = query(
+        collection(db, REPORTS_COLLECTION),
+        ...constraints
+    );
+
+    return onSnapshot(q, (snapshot) => {
+        const reports = snapshot.docs.map((d) => ({
+            id: d.id,
+            ...d.data(),
+            createdAt: d.data().createdAt?.toDate() || new Date(),
+            verifiedAt: d.data().verifiedAt?.toDate(),
+        })) as Report[];
+        callback(reports);
     });
 }
 


### PR DESCRIPTION
## Summary
- Replaced the static alert detail expansion (region/window/created metadata) with a live table of reports filtered by that alert's disease and region
- Each report row displays case ID, status, reporter, location, and date with a "View Report" button on the right
- Clicking "View Report" opens a dialog showing full report details (symptoms, danger signs, temperature, verification notes)
- Added `subscribeToReportsByDisease` service function for real-time Firestore queries by disease

## Test plan
- [ ] Open dashboard, expand an alert → verify reports table loads for that disease
- [ ] Click "View Report" → verify dialog shows full report details
- [ ] Collapse alert → verify no console errors (subscription cleanup)
- [ ] Expand alerts for different diseases → verify correct reports shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)