### PR TITLE
feat: volunteer-supervisor real-time messaging via Firestore

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -253,6 +253,20 @@
                     "order": "ASCENDING"
                 }
             ]
+        },
+        {
+            "collectionGroup": "conversations",
+            "queryScope": "COLLECTION",
+            "fields": [
+                {
+                    "fieldPath": "participantIds",
+                    "arrayConfig": "CONTAINS"
+                },
+                {
+                    "fieldPath": "lastMessageAt",
+                    "order": "DESCENDING"
+                }
+            ]
         }
     ],
     "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -116,5 +116,38 @@ service cloud.firestore {
       // Only Cloud Functions should write (no client writes)
       allow write: if false;
     }
+
+    // ── Conversations collection ──
+    match /conversations/{conversationId} {
+      // Participants can read conversations they belong to
+      allow read: if isApproved() &&
+        (resource.data.volunteerId == request.auth.uid ||
+         resource.data.supervisorId == request.auth.uid);
+
+      // Approved volunteers and supervisors can create conversations
+      allow create: if isApproved() &&
+        (hasRole('volunteer') || hasRole('supervisor')) &&
+        (request.resource.data.volunteerId == request.auth.uid ||
+         request.resource.data.supervisorId == request.auth.uid);
+
+      // Participants can update (for lastMessage, unreadCounts)
+      allow update: if isApproved() &&
+        (resource.data.volunteerId == request.auth.uid ||
+         resource.data.supervisorId == request.auth.uid);
+
+      // Messages subcollection
+      match /messages/{messageId} {
+        // Participants can read messages
+        allow read: if isApproved() &&
+          (get(/databases/$(database)/documents/conversations/$(conversationId)).data.volunteerId == request.auth.uid ||
+           get(/databases/$(database)/documents/conversations/$(conversationId)).data.supervisorId == request.auth.uid);
+
+        // Participants can create messages with their own senderId
+        allow create: if isApproved() &&
+          request.resource.data.senderId == request.auth.uid &&
+          (get(/databases/$(database)/documents/conversations/$(conversationId)).data.volunteerId == request.auth.uid ||
+           get(/databases/$(database)/documents/conversations/$(conversationId)).data.supervisorId == request.auth.uid);
+      }
+    }
   }
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -20,6 +20,7 @@ export function Sidebar() {
             { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
             { to: '/guide', icon: BookOpen, label: 'Guide' },
             { to: '/reports', icon: FileText, label: 'Reports' },
+            { to: '/messages', icon: MessageSquare, label: 'Messages' },
         );
     } else if (role === 'supervisor') {
         navItems.push(

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
-import { Search, Send, FileText, ArrowLeft } from 'lucide-react';
+import { useState, useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Search, Send, FileText, ArrowLeft, AlertTriangle, MapPin, Thermometer, Users, Clock } from 'lucide-react';
 import { Card, CardContent } from '../components/ui/card';
 import { Input } from '../components/ui/input';
 import { Button } from '../components/ui/button';
@@ -7,190 +8,31 @@ import { Badge } from '../components/ui/badge';
 import { Avatar, AvatarFallback } from '../components/ui/avatar';
 import { Textarea } from '../components/ui/textarea';
 import { ScrollArea } from '../components/ui/scroll-area';
+import { useAuth } from '../contexts/AuthContext';
+import {
+    subscribeToConversations,
+    subscribeToMessages,
+    sendMessage,
+    markConversationRead,
+    getReport,
+} from '../services/conversations';
+import type { Conversation, Message, Report } from '../types';
 
-interface Message {
-  id: string;
-  senderId: string;
-  senderName: string;
-  senderRole: 'volunteer' | 'supervisor';
-  text: string;
-  timestamp: string;
-}
-
-interface Conversation {
-  id: string;
-  volunteerId: string;
-  volunteerName: string;
-  reportId: string;
-  reportDisease: string;
-  reportDate: string;
-  lastMessage: string;
-  lastMessageTime: string;
-  unreadCount: number;
-  messages: Message[];
-}
-
-const conversations: Conversation[] = [
-  {
-    id: 'conv1',
-    volunteerId: 'v1',
-    volunteerName: 'Fatima Al-Masri',
-    reportId: 'VR001',
-    reportDisease: 'AWD',
-    reportDate: '2026-03-20',
-    lastMessage: 'Thank you for the verification. I will monitor the family.',
-    lastMessageTime: '2026-03-20 10:15',
-    unreadCount: 0,
-    messages: [
-      {
-        id: 'm1',
-        senderId: 'v1',
-        senderName: 'Fatima Al-Masri',
-        senderRole: 'volunteer',
-        text: 'I submitted a report for AWD affecting 3 family members. They are showing severe dehydration.',
-        timestamp: '2026-03-20 09:25'
-      },
-      {
-        id: 'm2',
-        senderId: 's1',
-        senderName: 'Ahmed Hassan',
-        senderRole: 'supervisor',
-        text: 'Received. Have they been referred to the health facility?',
-        timestamp: '2026-03-20 09:32'
-      },
-      {
-        id: 'm3',
-        senderId: 'v1',
-        senderName: 'Fatima Al-Masri',
-        senderRole: 'volunteer',
-        text: 'Yes, they were taken to the clinic 30 minutes ago. All three are receiving ORS.',
-        timestamp: '2026-03-20 09:45'
-      },
-      {
-        id: 'm4',
-        senderId: 's1',
-        senderName: 'Ahmed Hassan',
-        senderRole: 'supervisor',
-        text: 'Excellent work. I have verified your report. Please follow up with the family tomorrow and let me know their status.',
-        timestamp: '2026-03-20 10:05'
-      },
-      {
-        id: 'm5',
-        senderId: 'v1',
-        senderName: 'Fatima Al-Masri',
-        senderRole: 'volunteer',
-        text: 'Thank you for the verification. I will monitor the family.',
-        timestamp: '2026-03-20 10:15'
-      }
-    ]
-  },
-  {
-    id: 'conv2',
-    volunteerId: 'v2',
-    volunteerName: 'Omar Ibrahim',
-    reportId: 'VR002',
-    reportDisease: 'Measles',
-    reportDate: '2026-03-20',
-    lastMessage: 'Should I also check the siblings for symptoms?',
-    lastMessageTime: '2026-03-20 11:30',
-    unreadCount: 2,
-    messages: [
-      {
-        id: 'm1',
-        senderId: 'v2',
-        senderName: 'Omar Ibrahim',
-        senderRole: 'volunteer',
-        text: 'I have identified a suspected measles case - child with rash, fever, and red eyes for 4 days.',
-        timestamp: '2026-03-20 08:20'
-      },
-      {
-        id: 'm2',
-        senderId: 's1',
-        senderName: 'Ahmed Hassan',
-        senderRole: 'supervisor',
-        text: 'This is priority surveillance. Has the child been vaccinated? Please isolate immediately.',
-        timestamp: '2026-03-20 08:45'
-      },
-      {
-        id: 'm3',
-        senderId: 'v2',
-        senderName: 'Omar Ibrahim',
-        senderRole: 'volunteer',
-        text: 'Parents say vaccination records were lost during displacement. Child is now isolated at home.',
-        timestamp: '2026-03-20 11:15'
-      },
-      {
-        id: 'm4',
-        senderId: 'v2',
-        senderName: 'Omar Ibrahim',
-        senderRole: 'volunteer',
-        text: 'Should I also check the siblings for symptoms?',
-        timestamp: '2026-03-20 11:30'
-      }
-    ]
-  },
-  {
-    id: 'conv3',
-    volunteerId: 'v3',
-    volunteerName: 'Layla Hassan',
-    reportId: 'VR003',
-    reportDisease: 'SARI',
-    reportDate: '2026-03-19',
-    lastMessage: 'Report verified, thank you',
-    lastMessageTime: '2026-03-19 18:25',
-    unreadCount: 0,
-    messages: [
-      {
-        id: 'm1',
-        senderId: 'v3',
-        senderName: 'Layla Hassan',
-        senderRole: 'volunteer',
-        text: 'Two elderly patients with severe respiratory symptoms. Both have high fever and difficulty breathing.',
-        timestamp: '2026-03-19 16:50'
-      },
-      {
-        id: 'm2',
-        senderId: 's1',
-        senderName: 'Ahmed Hassan',
-        senderRole: 'supervisor',
-        text: 'Report verified, thank you',
-        timestamp: '2026-03-19 18:25'
-      }
-    ]
-  }
+const supervisorQuickReplies = [
+    'Please provide more details',
+    'Report verified, thank you',
+    'Please re-submit with corrections',
+    'Refer patient to health facility immediately',
 ];
 
-const quickReplies = [
-  'Please provide more details',
-  'Report verified, thank you',
-  'Please re-submit with corrections',
-  'Refer patient to health facility immediately'
+const volunteerQuickReplies = [
+    'Understood, will follow up',
+    'Patient has been referred',
+    'Status update: condition improving',
+    'Need more guidance',
 ];
 
-export function MessagesPage() {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [selectedConversation, setSelectedConversation] = useState<Conversation | null>(null);
-  const [messageText, setMessageText] = useState('');
-  const [showReportPanel, setShowReportPanel] = useState(false);
-
-  const filteredConversations = conversations.filter(conv =>
-    conv.volunteerName.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    conv.reportDisease.toLowerCase().includes(searchTerm.toLowerCase())
-  );
-
-  const handleSendMessage = () => {
-    if (!messageText.trim() || !selectedConversation) return;
-
-    console.log('Sending message:', messageText);
-    setMessageText('');
-  };
-
-  const handleQuickReply = (text: string) => {
-    setMessageText(text);
-  };
-
-  const formatTime = (timestamp: string) => {
-    const date = new Date(timestamp);
+function formatTime(date: Date) {
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffMins = Math.floor(diffMs / 60000);
@@ -202,230 +44,460 @@ export function MessagesPage() {
     if (diffHours < 24) return `${diffHours}h ago`;
     if (diffDays === 1) return 'Yesterday';
     return date.toLocaleDateString();
-  };
+}
 
-  if (selectedConversation) {
-    return (
-      <div className="space-y-4">
-        <Button variant="ghost" onClick={() => setSelectedConversation(null)}>
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Messages
-        </Button>
+function getStatusColor(status: string) {
+    switch (status) {
+        case 'verified': return 'bg-green-100 text-green-800';
+        case 'rejected': return 'bg-red-100 text-red-800';
+        default: return 'bg-yellow-100 text-yellow-800';
+    }
+}
 
-        <Card>
-          <div className="border-b p-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <Avatar className="w-10 h-10">
-                  <AvatarFallback className="bg-teal-100 text-teal-700">
-                    {selectedConversation.volunteerName.split(' ').map(n => n[0]).join('')}
-                  </AvatarFallback>
-                </Avatar>
-                <div>
-                  <h3 className="font-medium">{selectedConversation.volunteerName}</h3>
-                  <p className="text-sm text-gray-500">
-                    Re: {selectedConversation.reportDisease} Report — {new Date(selectedConversation.reportDate).toLocaleDateString()}
-                  </p>
-                </div>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowReportPanel(!showReportPanel)}
-              >
-                <FileText className="h-4 w-4 mr-2" />
-                View Report
-              </Button>
-            </div>
-          </div>
+export function MessagesPage() {
+    const { firebaseUser, userProfile } = useAuth();
+    const [searchParams] = useSearchParams();
 
-          <ScrollArea className="h-96 p-4">
+    const [conversations, setConversations] = useState<Conversation[]>([]);
+    const [selectedConversation, setSelectedConversation] = useState<Conversation | null>(null);
+    const [messages, setMessages] = useState<Message[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [messageText, setMessageText] = useState('');
+    const [showReportPanel, setShowReportPanel] = useState(false);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [reportDetail, setReportDetail] = useState<Report | null>(null);
+
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+    const conversationsLoadedRef = useRef(false);
+
+    const isVolunteer = userProfile?.role === 'volunteer';
+
+    const quickReplies = isVolunteer ? volunteerQuickReplies : supervisorQuickReplies;
+
+    // Get the other party's name for a conversation
+    const getOtherName = (conv: Conversation) =>
+        isVolunteer ? conv.supervisorName : conv.volunteerName;
+
+    const getOtherInitials = (conv: Conversation) =>
+        getOtherName(conv).split(' ').map(n => n[0]).join('');
+
+    // Subscribe to conversations
+    useEffect(() => {
+        if (!firebaseUser?.uid) return;
+
+        setLoading(true);
+        const unsubscribe = subscribeToConversations(firebaseUser.uid, (convs) => {
+            setConversations(convs);
+            setLoading(false);
+
+            // Auto-select conversation from URL params on first load
+            if (!conversationsLoadedRef.current) {
+                conversationsLoadedRef.current = true;
+                const targetId = searchParams.get('conversationId');
+                if (targetId) {
+                    const match = convs.find(c => c.id === targetId);
+                    if (match) {
+                        setSelectedConversation(match);
+                    }
+                }
+            }
+        });
+
+        return () => {
+            unsubscribe();
+            conversationsLoadedRef.current = false;
+        };
+    }, [firebaseUser?.uid, searchParams]);
+
+    // Subscribe to messages when a conversation is selected
+    useEffect(() => {
+        if (!selectedConversation || !firebaseUser?.uid) return;
+
+        markConversationRead(selectedConversation.id, firebaseUser.uid);
+
+        const unsubscribe = subscribeToMessages(selectedConversation.id, (msgs) => {
+            setMessages(msgs);
+        });
+
+        return () => unsubscribe();
+    }, [selectedConversation, firebaseUser?.uid]);
+
+    // Scroll to bottom when messages change
+    useEffect(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [messages]);
+
+    // Fetch report detail when panel is opened
+    useEffect(() => {
+        if (!showReportPanel || !selectedConversation) return;
+
+        setReportDetail(null);
+        getReport(selectedConversation.reportId).then((report) => {
+            setReportDetail(report);
+        });
+    }, [showReportPanel, selectedConversation]);
+
+    const handleSendMessage = async () => {
+        if (!messageText.trim() || !selectedConversation || !firebaseUser || !userProfile) return;
+
+        const text = messageText.trim();
+        setMessageText('');
+
+        const otherParticipantId = isVolunteer
+            ? selectedConversation.supervisorId
+            : selectedConversation.volunteerId;
+
+        await sendMessage(
+            selectedConversation.id,
+            {
+                senderId: firebaseUser.uid,
+                senderName: userProfile.displayName || 'Unknown',
+                senderRole: userProfile.role as 'volunteer' | 'supervisor',
+                text,
+            },
+            otherParticipantId
+        );
+    };
+
+    const handleQuickReply = (text: string) => {
+        setMessageText(text);
+    };
+
+    const filteredConversations = conversations.filter(conv => {
+        const otherName = getOtherName(conv);
+        return (
+            otherName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            conv.reportDisease.toLowerCase().includes(searchTerm.toLowerCase())
+        );
+    });
+
+    // Chat view
+    if (selectedConversation) {
+        return (
             <div className="space-y-4">
-              {selectedConversation.messages.map((message, idx) => {
-                const isVolunteer = message.senderRole === 'volunteer';
-                const showDateSeparator = idx === 0 ||
-                  new Date(message.timestamp).toDateString() !==
-                  new Date(selectedConversation.messages[idx - 1].timestamp).toDateString();
-
-                return (
-                  <div key={message.id}>
-                    {showDateSeparator && (
-                      <div className="flex items-center justify-center my-4">
-                        <span className="bg-gray-100 text-gray-600 px-3 py-1 rounded-full text-xs">
-                          {new Date(message.timestamp).toLocaleDateString('en-US', {
-                            weekday: 'long',
-                            year: 'numeric',
-                            month: 'long',
-                            day: 'numeric'
-                          })}
-                        </span>
-                      </div>
-                    )}
-
-                    <div className={`flex ${isVolunteer ? 'justify-start' : 'justify-end'}`}>
-                      <div className={`max-w-md ${isVolunteer ? 'mr-auto' : 'ml-auto'}`}>
-                        <div className={`rounded-lg p-3 ${
-                          isVolunteer ? 'bg-gray-100' : 'bg-teal-600 text-white'
-                        }`}>
-                          <p className="text-sm">{message.text}</p>
-                        </div>
-                        <p className={`text-xs text-gray-500 mt-1 ${isVolunteer ? 'text-left' : 'text-right'}`}>
-                          {new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </ScrollArea>
-
-          <div className="border-t p-4 space-y-3">
-            <div className="flex flex-wrap gap-2">
-              {quickReplies.map((reply, idx) => (
-                <Badge
-                  key={idx}
-                  variant="outline"
-                  className="cursor-pointer hover:bg-teal-50 hover:border-teal-500"
-                  onClick={() => handleQuickReply(reply)}
-                >
-                  {reply}
-                </Badge>
-              ))}
-            </div>
-
-            <div className="flex gap-2">
-              <Textarea
-                placeholder="Type your message..."
-                value={messageText}
-                onChange={(e) => setMessageText(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault();
-                    handleSendMessage();
-                  }
-                }}
-                className="min-h-[60px]"
-              />
-              <Button
-                className="bg-teal-600 hover:bg-teal-700"
-                onClick={handleSendMessage}
-                disabled={!messageText.trim()}
-              >
-                <Send className="h-4 w-4" />
-              </Button>
-            </div>
-
-            <p className="text-xs text-gray-500">
-              {messageText.trim() ? 'Press Enter to send, Shift+Enter for new line' : 'Messages queue offline and sync when online'}
-            </p>
-          </div>
-        </Card>
-
-        {showReportPanel && (
-          <Card className="bg-gray-50">
-            <CardContent className="pt-6">
-              <div className="flex items-start justify-between mb-4">
-                <h4 className="font-medium">Linked Report Summary</h4>
-                <Button variant="ghost" size="sm" onClick={() => setShowReportPanel(false)}>
-                  <ArrowLeft className="h-4 w-4" />
+                <Button variant="ghost" onClick={() => {
+                    setSelectedConversation(null);
+                    setShowReportPanel(false);
+                    setReportDetail(null);
+                    setMessages([]);
+                }}>
+                    <ArrowLeft className="h-4 w-4 mr-2" />
+                    Back to Messages
                 </Button>
-              </div>
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Report ID:</span>
-                  <span className="font-medium">{selectedConversation.reportId}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Disease:</span>
-                  <span className="font-medium">{selectedConversation.reportDisease}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-gray-600">Submitted:</span>
-                  <span className="font-medium">{new Date(selectedConversation.reportDate).toLocaleDateString()}</span>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-      </div>
-    );
-  }
 
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl text-gray-900">Messages</h1>
-        <p className="text-sm text-gray-500 mt-1">Communicate with volunteers about their reports</p>
-      </div>
-
-      <Card>
-        <CardContent className="pt-6">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-            <Input
-              placeholder="Search by volunteer name or disease..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-10"
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      <div className="space-y-3">
-        {filteredConversations.map(conv => (
-          <Card
-            key={conv.id}
-            className="cursor-pointer hover:shadow-md transition-shadow"
-            onClick={() => setSelectedConversation(conv)}
-          >
-            <CardContent className="pt-6">
-              <div className="flex items-start gap-4">
-                <Avatar className="w-12 h-12">
-                  <AvatarFallback className="bg-teal-100 text-teal-700">
-                    {conv.volunteerName.split(' ').map(n => n[0]).join('')}
-                  </AvatarFallback>
-                </Avatar>
-
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center justify-between mb-1">
-                    <h3 className={`font-medium ${conv.unreadCount > 0 ? 'text-gray-900' : 'text-gray-700'}`}>
-                      {conv.volunteerName}
-                    </h3>
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs text-gray-500">{formatTime(conv.lastMessageTime)}</span>
-                      {conv.unreadCount > 0 && (
-                        <Badge className="bg-red-500">{conv.unreadCount}</Badge>
-                      )}
+                <Card>
+                    <div className="border-b p-4">
+                        <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-3">
+                                <Avatar className="w-10 h-10">
+                                    <AvatarFallback className="bg-teal-100 text-teal-700">
+                                        {getOtherInitials(selectedConversation)}
+                                    </AvatarFallback>
+                                </Avatar>
+                                <div>
+                                    <h3 className="font-medium">{getOtherName(selectedConversation)}</h3>
+                                    <p className="text-sm text-gray-500">
+                                        Re: {selectedConversation.reportDisease} Report — {selectedConversation.reportDate.toLocaleDateString()}
+                                    </p>
+                                </div>
+                            </div>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setShowReportPanel(!showReportPanel)}
+                            >
+                                <FileText className="h-4 w-4 mr-2" />
+                                View Report
+                            </Button>
+                        </div>
                     </div>
-                  </div>
 
-                  <p className="text-sm text-gray-600 truncate mb-2">{conv.lastMessage}</p>
+                    <ScrollArea className="h-96 p-4">
+                        <div className="space-y-4">
+                            {messages.map((message, idx) => {
+                                const isOwn = message.senderId === firebaseUser?.uid;
+                                const showDateSeparator = idx === 0 ||
+                                    message.sentAt.toDateString() !== messages[idx - 1].sentAt.toDateString();
 
-                  <Badge variant="outline" className="text-xs">
-                    <FileText className="h-3 w-3 mr-1" />
-                    {conv.reportDisease} Report
-                  </Badge>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+                                return (
+                                    <div key={message.id}>
+                                        {showDateSeparator && (
+                                            <div className="flex items-center justify-center my-4">
+                                                <span className="bg-gray-100 text-gray-600 px-3 py-1 rounded-full text-xs">
+                                                    {message.sentAt.toLocaleDateString('en-US', {
+                                                        weekday: 'long',
+                                                        year: 'numeric',
+                                                        month: 'long',
+                                                        day: 'numeric',
+                                                    })}
+                                                </span>
+                                            </div>
+                                        )}
 
-      {filteredConversations.length === 0 && (
-        <Card>
-          <CardContent className="py-12 text-center">
-            <p className="text-gray-500">
-              {searchTerm
-                ? `No conversations found matching "${searchTerm}"`
-                : 'No messages yet — conversations appear when volunteers message about their reports'
-              }
-            </p>
-          </CardContent>
-        </Card>
-      )}
-    </div>
-  );
+                                        <div className={`flex ${isOwn ? 'justify-end' : 'justify-start'}`}>
+                                            <div className={`max-w-md ${isOwn ? 'ml-auto' : 'mr-auto'}`}>
+                                                <div className={`rounded-lg p-3 ${
+                                                    isOwn ? 'bg-teal-600 text-white' : 'bg-gray-100'
+                                                }`}>
+                                                    <p className="text-sm">{message.text}</p>
+                                                </div>
+                                                <p className={`text-xs text-gray-500 mt-1 ${isOwn ? 'text-right' : 'text-left'}`}>
+                                                    {message.sentAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                            <div ref={messagesEndRef} />
+                        </div>
+                    </ScrollArea>
+
+                    <div className="border-t p-4 space-y-3">
+                        <div className="flex flex-wrap gap-2">
+                            {quickReplies.map((reply, idx) => (
+                                <Badge
+                                    key={idx}
+                                    variant="outline"
+                                    className="cursor-pointer hover:bg-teal-50 hover:border-teal-500"
+                                    onClick={() => handleQuickReply(reply)}
+                                >
+                                    {reply}
+                                </Badge>
+                            ))}
+                        </div>
+
+                        <div className="flex gap-2">
+                            <Textarea
+                                placeholder="Type your message..."
+                                value={messageText}
+                                onChange={(e) => setMessageText(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' && !e.shiftKey) {
+                                        e.preventDefault();
+                                        handleSendMessage();
+                                    }
+                                }}
+                                className="min-h-[60px]"
+                            />
+                            <Button
+                                className="bg-teal-600 hover:bg-teal-700"
+                                onClick={handleSendMessage}
+                                disabled={!messageText.trim()}
+                            >
+                                <Send className="h-4 w-4" />
+                            </Button>
+                        </div>
+
+                        <p className="text-xs text-gray-500">
+                            {messageText.trim() ? 'Press Enter to send, Shift+Enter for new line' : 'Messages queue offline and sync when online'}
+                        </p>
+                    </div>
+                </Card>
+
+                {showReportPanel && (
+                    <Card className="bg-gray-50">
+                        <CardContent className="pt-6">
+                            <div className="flex items-start justify-between mb-4">
+                                <h4 className="font-medium">Linked Report Details</h4>
+                                <Button variant="ghost" size="sm" onClick={() => setShowReportPanel(false)}>
+                                    <ArrowLeft className="h-4 w-4" />
+                                </Button>
+                            </div>
+
+                            {!reportDetail ? (
+                                <p className="text-sm text-gray-500">Loading report...</p>
+                            ) : (
+                                <div className="space-y-4">
+                                    <div className="space-y-2 text-sm">
+                                        {reportDetail.caseId && (
+                                            <div className="flex justify-between">
+                                                <span className="text-gray-600">Case ID:</span>
+                                                <span className="font-medium">{reportDetail.caseId}</span>
+                                            </div>
+                                        )}
+                                        <div className="flex justify-between">
+                                            <span className="text-gray-600">Disease:</span>
+                                            <span className="font-medium">{reportDetail.disease}</span>
+                                        </div>
+                                        <div className="flex justify-between items-center">
+                                            <span className="text-gray-600">Status:</span>
+                                            <Badge className={getStatusColor(reportDetail.status)}>
+                                                {reportDetail.status}
+                                            </Badge>
+                                        </div>
+                                        <div className="flex justify-between">
+                                            <span className="text-gray-600">Reporter:</span>
+                                            <span className="font-medium">{reportDetail.reporterName || 'Unknown'}</span>
+                                        </div>
+                                        <div className="flex justify-between items-start">
+                                            <span className="text-gray-600 flex items-center gap-1">
+                                                <MapPin className="h-3 w-3" /> Location:
+                                            </span>
+                                            <span className="font-medium text-right">{reportDetail.location.name || `${reportDetail.location.lat}, ${reportDetail.location.lng}`}</span>
+                                        </div>
+                                        <div className="flex justify-between">
+                                            <span className="text-gray-600 flex items-center gap-1">
+                                                <Users className="h-3 w-3" /> Persons:
+                                            </span>
+                                            <span className="font-medium">{reportDetail.personsCount}</span>
+                                        </div>
+                                        {reportDetail.temp !== undefined && (
+                                            <div className="flex justify-between">
+                                                <span className="text-gray-600 flex items-center gap-1">
+                                                    <Thermometer className="h-3 w-3" /> Temperature:
+                                                </span>
+                                                <span className="font-medium">{reportDetail.temp}&deg;C</span>
+                                            </div>
+                                        )}
+                                        <div className="flex justify-between">
+                                            <span className="text-gray-600 flex items-center gap-1">
+                                                <Clock className="h-3 w-3" /> Submitted:
+                                            </span>
+                                            <span className="font-medium">{reportDetail.createdAt.toLocaleDateString()}</span>
+                                        </div>
+                                    </div>
+
+                                    {reportDetail.symptoms.length > 0 && (
+                                        <div>
+                                            <p className="text-sm text-gray-600 mb-2">Symptoms:</p>
+                                            <div className="flex flex-wrap gap-1">
+                                                {reportDetail.symptoms.map((symptom, idx) => (
+                                                    <Badge key={idx} variant="outline" className="text-xs">
+                                                        {symptom}
+                                                    </Badge>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {reportDetail.dangerSigns && reportDetail.dangerSigns.length > 0 && (
+                                        <div>
+                                            <p className="text-sm text-gray-600 mb-2">Danger Signs:</p>
+                                            <div className="flex flex-wrap gap-1">
+                                                {reportDetail.dangerSigns.map((sign, idx) => (
+                                                    <Badge key={idx} variant="outline" className="text-xs border-red-300 text-red-700 bg-red-50">
+                                                        <AlertTriangle className="h-3 w-3 mr-1" />
+                                                        {sign}
+                                                    </Badge>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    {reportDetail.verificationNotes && (
+                                        <div>
+                                            <p className="text-sm text-gray-600 mb-1">Verification Notes:</p>
+                                            <p className="text-sm bg-white rounded p-2 border">{reportDetail.verificationNotes}</p>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                        </CardContent>
+                    </Card>
+                )}
+            </div>
+        );
+    }
+
+    // Conversation list view
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-2xl text-gray-900">Messages</h1>
+                <p className="text-sm text-gray-500 mt-1">
+                    {isVolunteer
+                        ? 'Communicate with your supervisor about reports'
+                        : 'Communicate with volunteers about their reports'}
+                </p>
+            </div>
+
+            <Card>
+                <CardContent className="pt-6">
+                    <div className="relative">
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                        <Input
+                            placeholder={isVolunteer ? 'Search by supervisor name or disease...' : 'Search by volunteer name or disease...'}
+                            value={searchTerm}
+                            onChange={(e) => setSearchTerm(e.target.value)}
+                            className="pl-10"
+                        />
+                    </div>
+                </CardContent>
+            </Card>
+
+            {loading ? (
+                <Card>
+                    <CardContent className="py-12 text-center">
+                        <p className="text-gray-500">Loading conversations...</p>
+                    </CardContent>
+                </Card>
+            ) : (
+                <>
+                    <div className="space-y-3">
+                        {filteredConversations.map(conv => {
+                            const unreadCount = conv.unreadCounts[firebaseUser?.uid || ''] || 0;
+                            const otherName = getOtherName(conv);
+                            const otherInitials = getOtherInitials(conv);
+                            const subtitle = isVolunteer
+                                ? `Supervisor: ${conv.supervisorName}`
+                                : `Volunteer: ${conv.volunteerName}`;
+
+                            return (
+                                <Card
+                                    key={conv.id}
+                                    className="cursor-pointer hover:shadow-md transition-shadow"
+                                    onClick={() => setSelectedConversation(conv)}
+                                >
+                                    <CardContent className="pt-6">
+                                        <div className="flex items-start gap-4">
+                                            <Avatar className="w-12 h-12">
+                                                <AvatarFallback className="bg-teal-100 text-teal-700">
+                                                    {otherInitials}
+                                                </AvatarFallback>
+                                            </Avatar>
+
+                                            <div className="flex-1 min-w-0">
+                                                <div className="flex items-center justify-between mb-1">
+                                                    <h3 className={`font-medium ${unreadCount > 0 ? 'text-gray-900' : 'text-gray-700'}`}>
+                                                        {otherName}
+                                                    </h3>
+                                                    <div className="flex items-center gap-2">
+                                                        <span className="text-xs text-gray-500">{formatTime(conv.lastMessageAt)}</span>
+                                                        {unreadCount > 0 && (
+                                                            <Badge className="bg-red-500">{unreadCount}</Badge>
+                                                        )}
+                                                    </div>
+                                                </div>
+
+                                                <p className="text-xs text-gray-500 mb-1">{subtitle}</p>
+                                                <p className="text-sm text-gray-600 truncate mb-2">{conv.lastMessage}</p>
+
+                                                <Badge variant="outline" className="text-xs">
+                                                    <FileText className="h-3 w-3 mr-1" />
+                                                    {conv.reportDisease} Report
+                                                </Badge>
+                                            </div>
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            );
+                        })}
+                    </div>
+
+                    {filteredConversations.length === 0 && (
+                        <Card>
+                            <CardContent className="py-12 text-center">
+                                <p className="text-gray-500">
+                                    {searchTerm
+                                        ? `No conversations found matching "${searchTerm}"`
+                                        : 'No conversations yet -- conversations appear when messages are exchanged about reports'}
+                                </p>
+                            </CardContent>
+                        </Card>
+                    )}
+                </>
+            )}
+        </div>
+    );
 }

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
-import { Filter, CheckCircle, X, AlertTriangle, MapPin, Thermometer, Users, Clock } from 'lucide-react';
+import { Filter, CheckCircle, X, AlertTriangle, MapPin, Thermometer, Users, Clock, MessageSquare } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { findConversationByReport, createConversation } from '../services/conversations';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { Card, CardContent } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
@@ -23,6 +25,7 @@ export function ReportsPage() {
     const [actionType, setActionType] = useState<'verify' | 'reject' | null>(null);
     const [actionNotes, setActionNotes] = useState('');
     const [actionLoading, setActionLoading] = useState(false);
+    const navigate = useNavigate();
 
     useEffect(() => {
         if (!userProfile?.region) return;
@@ -76,6 +79,45 @@ export function ReportsPage() {
             setSelectedReport(null);
             setActionType(null);
             setActionNotes('');
+        }
+    };
+
+    const handleMessage = async (report: Report) => {
+        if (!firebaseUser || !userProfile) return;
+        try {
+            const existing = await findConversationByReport(report.id);
+            if (existing) {
+                navigate(`/messages?conversationId=${existing.id}`);
+                return;
+            }
+            // Determine volunteer/supervisor fields
+            let volunteerId: string, volunteerName: string, supervisorId: string, supervisorName: string;
+            if (userProfile.role === 'supervisor') {
+                volunteerId = report.reporterId;
+                volunteerName = report.reporterName || 'Unknown';
+                supervisorId = firebaseUser.uid;
+                supervisorName = userProfile.displayName;
+            } else {
+                // Volunteer
+                volunteerId = firebaseUser.uid;
+                volunteerName = userProfile.displayName;
+                supervisorId = userProfile.supervisorId || '';
+                supervisorName = ''; // Will be resolved later
+            }
+            const newId = await createConversation({
+                reportId: report.id,
+                reportDisease: report.disease,
+                reportDate: report.createdAt,
+                volunteerId,
+                volunteerName,
+                supervisorId,
+                supervisorName,
+                participantIds: [volunteerId, supervisorId],
+                region: report.region,
+            });
+            navigate(`/messages?conversationId=${newId}`);
+        } catch (err) {
+            console.error('Failed to start conversation:', err);
         }
     };
 
@@ -151,6 +193,20 @@ export function ReportsPage() {
                                 </div>
                             )}
                         </div>
+                    </div>
+                    <div className="flex gap-2 mt-4">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="border-teal-500 text-teal-600 hover:bg-teal-50"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                handleMessage(report);
+                            }}
+                        >
+                            <MessageSquare className="h-4 w-4 mr-2" />
+                            Message
+                        </Button>
                     </div>
                     {showActions && report.status === 'pending' && (
                         <div className="flex gap-2 mt-4">

--- a/src/services/conversations.ts
+++ b/src/services/conversations.ts
@@ -1,0 +1,179 @@
+import {
+    collection,
+    addDoc,
+    doc,
+    updateDoc,
+    query,
+    where,
+    orderBy,
+    limit,
+    onSnapshot,
+    serverTimestamp,
+    getDocs,
+    getDoc,
+    increment,
+    type Unsubscribe,
+} from 'firebase/firestore';
+import { db } from './firebase';
+import type { Conversation, Message, Report } from '../types';
+
+const CONVERSATIONS_COLLECTION = 'conversations';
+const MESSAGES_SUBCOLLECTION = 'messages';
+const REPORTS_COLLECTION = 'reports';
+
+/**
+ * Subscribe to all conversations for a given user (volunteer or supervisor).
+ */
+export function subscribeToConversations(
+    userId: string,
+    callback: (convs: Conversation[]) => void
+): Unsubscribe {
+    const q = query(
+        collection(db, CONVERSATIONS_COLLECTION),
+        where('participantIds', 'array-contains', userId),
+        orderBy('lastMessageAt', 'desc')
+    );
+
+    return onSnapshot(q, (snapshot) => {
+        const convs = snapshot.docs.map((d) => ({
+            id: d.id,
+            ...d.data(),
+            lastMessageAt: d.data().lastMessageAt?.toDate() || new Date(),
+            reportDate: d.data().reportDate?.toDate() || new Date(),
+            createdAt: d.data().createdAt?.toDate() || new Date(),
+        })) as Conversation[];
+        callback(convs);
+    });
+}
+
+/**
+ * Subscribe to messages within a conversation.
+ */
+export function subscribeToMessages(
+    conversationId: string,
+    callback: (msgs: Message[]) => void
+): Unsubscribe {
+    const q = query(
+        collection(db, CONVERSATIONS_COLLECTION, conversationId, MESSAGES_SUBCOLLECTION),
+        orderBy('sentAt', 'asc')
+    );
+
+    return onSnapshot(q, (snapshot) => {
+        const msgs = snapshot.docs.map((d) => ({
+            id: d.id,
+            ...d.data(),
+            sentAt: d.data().sentAt?.toDate() || new Date(),
+        })) as Message[];
+        callback(msgs);
+    });
+}
+
+/**
+ * Send a message in a conversation and update the parent conversation metadata.
+ */
+export async function sendMessage(
+    conversationId: string,
+    data: {
+        senderId: string;
+        senderName: string;
+        senderRole: 'volunteer' | 'supervisor';
+        text: string;
+    },
+    otherParticipantId: string
+): Promise<void> {
+    const messagesRef = collection(
+        db,
+        CONVERSATIONS_COLLECTION,
+        conversationId,
+        MESSAGES_SUBCOLLECTION
+    );
+
+    await addDoc(messagesRef, {
+        senderId: data.senderId,
+        senderName: data.senderName,
+        senderRole: data.senderRole,
+        text: data.text,
+        sentAt: serverTimestamp(),
+        read: false,
+    });
+
+    const convRef = doc(db, CONVERSATIONS_COLLECTION, conversationId);
+    await updateDoc(convRef, {
+        lastMessage: data.text,
+        lastMessageAt: serverTimestamp(),
+        [`unreadCounts.${otherParticipantId}`]: increment(1),
+    });
+}
+
+/**
+ * Create a new conversation linked to a report.
+ */
+export async function createConversation(
+    data: Omit<Conversation, 'id' | 'lastMessage' | 'lastMessageAt' | 'unreadCounts' | 'createdAt'>
+): Promise<string> {
+    const docRef = await addDoc(collection(db, CONVERSATIONS_COLLECTION), {
+        ...data,
+        unreadCounts: {
+            [data.volunteerId]: 0,
+            [data.supervisorId]: 0,
+        },
+        lastMessage: '',
+        lastMessageAt: serverTimestamp(),
+        createdAt: serverTimestamp(),
+    });
+    return docRef.id;
+}
+
+/**
+ * Find an existing conversation for a given report.
+ */
+export async function findConversationByReport(
+    reportId: string
+): Promise<Conversation | null> {
+    const q = query(
+        collection(db, CONVERSATIONS_COLLECTION),
+        where('reportId', '==', reportId),
+        limit(1)
+    );
+
+    const snapshot = await getDocs(q);
+    if (snapshot.empty) return null;
+
+    const d = snapshot.docs[0];
+    return {
+        id: d.id,
+        ...d.data(),
+        lastMessageAt: d.data().lastMessageAt?.toDate() || new Date(),
+        reportDate: d.data().reportDate?.toDate() || new Date(),
+        createdAt: d.data().createdAt?.toDate() || new Date(),
+    } as Conversation;
+}
+
+/**
+ * Reset unread count for a user in a conversation.
+ */
+export async function markConversationRead(
+    conversationId: string,
+    userId: string
+): Promise<void> {
+    const convRef = doc(db, CONVERSATIONS_COLLECTION, conversationId);
+    await updateDoc(convRef, {
+        [`unreadCounts.${userId}`]: 0,
+    });
+}
+
+/**
+ * Fetch a single report by ID.
+ */
+export async function getReport(reportId: string): Promise<Report | null> {
+    const reportRef = doc(db, REPORTS_COLLECTION, reportId);
+    const snapshot = await getDoc(reportRef);
+    if (!snapshot.exists()) return null;
+
+    return {
+        id: snapshot.id,
+        ...snapshot.data(),
+        createdAt: snapshot.data().createdAt?.toDate() || new Date(),
+        verifiedAt: snapshot.data().verifiedAt?.toDate(),
+    } as Report;
+}

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -1,0 +1,26 @@
+export interface Conversation {
+    id: string;
+    reportId: string;
+    reportDisease: string;
+    reportDate: Date;
+    volunteerId: string;
+    volunteerName: string;
+    supervisorId: string;
+    supervisorName: string;
+    participantIds: string[];
+    region: string;
+    lastMessage: string;
+    lastMessageAt: Date;
+    unreadCounts: Record<string, number>;
+    createdAt: Date;
+}
+
+export interface Message {
+    id: string;
+    senderId: string;
+    senderName: string;
+    senderRole: 'volunteer' | 'supervisor';
+    text: string;
+    sentAt: Date;
+    read: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export type { User, UserRole, UserStatus } from './user';
 export type { Report, ReportStatus, ReportLocation, QuestionAnswer } from './report';
 export type { CaseDefinition, AssessmentQuestion, AlertThreshold, ThresholdType } from './caseDefinition';
 export type { Alert, AlertSeverity, AlertStatus, Aggregate, AggregatePeriod } from './alert';
+export type { Conversation, Message } from './conversation';


### PR DESCRIPTION
## Summary
- Replace hardcoded mock data in MessagesPage with real Firestore subscriptions for conversations and messages between volunteers and supervisors
- Add new `Conversation` and `Message` types plus a full conversations service layer (subscribe, send, create, find, mark-read, get-report)
- Add "Message" button on report cards in ReportsPage that creates or finds an existing conversation and navigates to it
- Enable Messages nav item in the sidebar for volunteers (previously supervisor-only)
- Add Firestore security rules scoping conversation read/write to participants, and a composite index for participant-based queries
- View Report panel now fetches and displays full report details (symptoms, danger signs, location, status) instead of minimal mock info

## Test plan
- [ ] Log in as supervisor, click "Message" on a report card — conversation created, navigates to Messages page with it selected
- [ ] Log in as volunteer — Messages nav appears in sidebar; click "Message" on own report — same flow
- [ ] Send messages from both roles — bubbles appear real-time, own messages on right, other's on left
- [ ] Quick reply buttons show role-appropriate options and populate text input
- [ ] Unread counts update when the other party sends a message
- [ ] "View Report" button shows full report details (symptoms, danger signs, location, status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)