### PR TITLE
fix: resolve messages page stuck on loading conversations

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -139,8 +139,7 @@ service cloud.firestore {
     match /conversations/{conversationId} {
       // Participants can read conversations they belong to
       allow read: if isApproved() &&
-        (resource.data.volunteerId == request.auth.uid ||
-         resource.data.supervisorId == request.auth.uid);
+        request.auth.uid in resource.data.participantIds;
 
       // Approved volunteers and supervisors can create conversations
       allow create: if isApproved() &&

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -99,6 +99,9 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
                 return sum + (conv.unreadCounts?.[userId] || 0);
             }, 0);
             setConversationUnread(total);
+        }, (error) => {
+            console.error('Conversation unread subscription error:', error);
+            setConversationUnread(0);
         });
 
         return unsub;

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -101,6 +101,9 @@ export function MessagesPage() {
                     }
                 }
             }
+        }, (error) => {
+            console.error('Conversations subscription error:', error);
+            setLoading(false);
         });
 
         return () => {

--- a/src/services/conversations.ts
+++ b/src/services/conversations.ts
@@ -26,7 +26,8 @@ const REPORTS_COLLECTION = 'reports';
  */
 export function subscribeToConversations(
     userId: string,
-    callback: (convs: Conversation[]) => void
+    callback: (convs: Conversation[]) => void,
+    onError?: (error: Error) => void
 ): Unsubscribe {
     const q = query(
         collection(db, CONVERSATIONS_COLLECTION),
@@ -43,6 +44,9 @@ export function subscribeToConversations(
             createdAt: d.data().createdAt?.toDate() || new Date(),
         })) as Conversation[];
         callback(convs);
+    }, (error) => {
+        console.error('Failed to load conversations:', error);
+        onError?.(error);
     });
 }
 


### PR DESCRIPTION
## Summary
- Updated Firestore security rules for conversations to use `participantIds` array instead of `volunteerId`/`supervisorId` field checks, so the `array-contains` query is no longer rejected by security rules
- Added `onError` callback to `subscribeToConversations` so Firestore permission errors don't silently hang the loading state
- Wired error handlers in `MessagesPage` and `NotificationContext` to clear loading and reset unread counts on failure

## Test plan
- [ ] Log in as a supervisor and navigate to Messages — conversations should load (or show "No conversations yet")
- [ ] Check browser console for no Firestore permission errors
- [ ] Verify notification badge still updates correctly
- [ ] Test offline/reconnect behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)