### PR TITLE
fix: raise header z-index above Leaflet heatmap layers

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,7 +37,7 @@ export function Header() {
     };
 
     return (
-        <header className="bg-white border-b border-gray-200 px-6 py-4 sticky top-0 z-50">
+        <header className="bg-white border-b border-gray-200 px-6 py-4 sticky top-0 z-[1001]">
             <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-4">
                     <div className="w-10 h-10 bg-gradient-to-br from-teal-600 to-blue-600 rounded-lg flex items-center justify-center">


### PR DESCRIPTION
## Summary
- The sticky header had `z-50` (z-index: 50), which was lower than Leaflet's internal pane z-index values (up to ~700), causing the disease heatmap to render on top of the navigation bar.
- Bumped the header z-index to `z-[1001]` so it stays above all Leaflet map layers.

## Test plan
- [ ] Open a dashboard page with the heatmap visible
- [ ] Confirm the header renders above the map and heatmap layer
- [ ] Confirm map legends still display correctly within the map
- [ ] Confirm header dropdown menus still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)