### PR TITLE
fix: Message button navigates immediately, resolves conversation on MessagesPage

### DIFF
--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -15,6 +15,7 @@ import {
     sendMessage,
     markConversationRead,
     getReport,
+    createConversation,
 } from '../services/conversations';
 import type { Conversation, Message, Report } from '../types';
 
@@ -66,6 +67,8 @@ export function MessagesPage() {
     const [showReportPanel, setShowReportPanel] = useState(false);
     const [searchTerm, setSearchTerm] = useState('');
     const [reportDetail, setReportDetail] = useState<Report | null>(null);
+    const [conversationLoading, setConversationLoading] = useState(false);
+    const [conversationError, setConversationError] = useState<string | null>(null);
 
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const conversationsLoadedRef = useRef(false);
@@ -108,6 +111,53 @@ export function MessagesPage() {
             conversationsLoadedRef.current = false;
         };
     }, [firebaseUser?.uid, searchParams]);
+
+    // Handle reportId URL param — find or create conversation
+    useEffect(() => {
+        const reportId = searchParams.get('reportId');
+        if (!reportId || loading || !firebaseUser?.uid || !userProfile) return;
+
+        // Check if conversation for this report already exists
+        const existing = conversations.find(c => c.reportId === reportId);
+        if (existing) {
+            setSelectedConversation(existing);
+            setConversationLoading(false);
+            setConversationError(null);
+            return;
+        }
+
+        // Don't create if already creating
+        if (conversationLoading) return;
+
+        const reportDisease = searchParams.get('reportDisease') || '';
+        const reportDateStr = searchParams.get('reportDate');
+        const volunteerId = searchParams.get('volunteerId') || '';
+        const volunteerName = searchParams.get('volunteerName') || 'Unknown';
+        const region = searchParams.get('region') || '';
+
+        setConversationLoading(true);
+        setConversationError(null);
+
+        createConversation({
+            reportId,
+            reportDisease,
+            reportDate: reportDateStr ? new Date(reportDateStr) : new Date(),
+            volunteerId,
+            volunteerName,
+            supervisorId: firebaseUser.uid,
+            supervisorName: userProfile.displayName,
+            participantIds: [volunteerId, firebaseUser.uid],
+            region,
+        })
+            .then(() => {
+                // onSnapshot will pick up the new conversation; the effect re-runs to select it
+            })
+            .catch((err) => {
+                console.error('Failed to create conversation:', err);
+                setConversationError('Failed to start conversation. Please try again.');
+                setConversationLoading(false);
+            });
+    }, [searchParams, loading, conversations, firebaseUser?.uid, userProfile, conversationLoading]);
 
     // Subscribe to messages when a conversation is selected
     useEffect(() => {
@@ -434,6 +484,22 @@ export function MessagesPage() {
                 </Card>
             ) : (
                 <>
+                    {conversationLoading && (
+                        <Card className="border-teal-200 bg-teal-50">
+                            <CardContent className="py-6 text-center">
+                                <p className="text-teal-700">Starting conversation...</p>
+                            </CardContent>
+                        </Card>
+                    )}
+
+                    {conversationError && (
+                        <Card className="border-red-200 bg-red-50">
+                            <CardContent className="py-6 text-center">
+                                <p className="text-red-700">{conversationError}</p>
+                            </CardContent>
+                        </Card>
+                    )}
+
                     <div className="space-y-3">
                         {filteredConversations.map(conv => {
                             const unreadCount = conv.unreadCounts[firebaseUser?.uid || ''] || 0;

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Filter, CheckCircle, X, AlertTriangle, MapPin, Thermometer, Users, Clock, MessageSquare } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { findConversationByReport, createConversation } from '../services/conversations';
+
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { Card, CardContent } from '../components/ui/card';
 import { Badge } from '../components/ui/badge';
@@ -82,43 +82,17 @@ export function ReportsPage() {
         }
     };
 
-    const handleMessage = async (report: Report) => {
+    const handleMessage = (report: Report) => {
         if (!firebaseUser || !userProfile) return;
-        try {
-            const existing = await findConversationByReport(report.id);
-            if (existing) {
-                navigate(`/messages?conversationId=${existing.id}`);
-                return;
-            }
-            // Determine volunteer/supervisor fields
-            let volunteerId: string, volunteerName: string, supervisorId: string, supervisorName: string;
-            if (userProfile.role === 'supervisor') {
-                volunteerId = report.reporterId;
-                volunteerName = report.reporterName || 'Unknown';
-                supervisorId = firebaseUser.uid;
-                supervisorName = userProfile.displayName;
-            } else {
-                // Volunteer
-                volunteerId = firebaseUser.uid;
-                volunteerName = userProfile.displayName;
-                supervisorId = userProfile.supervisorId || '';
-                supervisorName = ''; // Will be resolved later
-            }
-            const newId = await createConversation({
-                reportId: report.id,
-                reportDisease: report.disease,
-                reportDate: report.createdAt,
-                volunteerId,
-                volunteerName,
-                supervisorId,
-                supervisorName,
-                participantIds: [volunteerId, supervisorId],
-                region: report.region,
-            });
-            navigate(`/messages?conversationId=${newId}`);
-        } catch (err) {
-            console.error('Failed to start conversation:', err);
-        }
+        const params = new URLSearchParams({
+            reportId: report.id,
+            reportDisease: report.disease,
+            reportDate: report.createdAt.toISOString(),
+            volunteerId: report.reporterId,
+            volunteerName: report.reporterName || 'Unknown',
+            region: report.region,
+        });
+        navigate(`/messages?${params.toString()}`);
     };
 
     const ReportCard = ({ report, showActions = true }: { report: Report; showActions?: boolean }) => (


### PR DESCRIPTION
## Summary
- **ReportsPage**: Simplified the Message button handler to navigate immediately with report context as URL params, removing the async Firestore lookup that could silently fail.
- **MessagesPage**: Added a `useEffect` that detects `reportId` in URL params, finds an existing conversation or creates a new one, and auto-selects it once the real-time listener picks it up.
- Added inline loading ("Starting conversation...") and error UI for conversation creation feedback.

## Test plan
- [ ] Log in as supervisor, click Message on a report → navigates to Messages, briefly shows "Starting conversation...", then opens the chat
- [ ] Click Message on the same report again → navigates and immediately selects the existing conversation
- [ ] Verify existing `conversationId` URL param flow still works (sidebar Messages link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)