### PR TITLE
fix: hide dashboard and volunteers pages from volunteer role

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,7 +17,6 @@ export function Sidebar() {
 
     if (role === 'volunteer') {
         navItems.push(
-            { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
             { to: '/guide', icon: BookOpen, label: 'Guide' },
             { to: '/reports', icon: FileText, label: 'Reports' },
             { to: '/messages', icon: MessageSquare, label: 'Messages' },

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -1,6 +1,8 @@
 import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
 import ProtectedRoute from './ProtectedRoute';
+import RoleGuard from './RoleGuard';
 import { RootLayout } from '../components/RootLayout';
+import { useAuth } from '../contexts/AuthContext';
 
 // Auth pages
 import { LoginPage } from '../pages/auth/LoginPage';
@@ -17,6 +19,15 @@ import { ProfilePage } from '../pages/ProfilePage';
 import { NotificationsPage } from '../pages/NotificationsPage';
 import { NotFoundPage } from '../pages/NotFoundPage';
 
+/** Redirects volunteers to /reports; shows Dashboard for other roles */
+function IndexRedirect() {
+    const { userProfile } = useAuth();
+    if (userProfile?.role === 'volunteer') {
+        return <Navigate to="/reports" replace />;
+    }
+    return <DashboardPage />;
+}
+
 export const router = createBrowserRouter([
     // Public routes
     { path: '/login', element: <LoginPage /> },
@@ -31,12 +42,12 @@ export const router = createBrowserRouter([
             </ProtectedRoute>
         ),
         children: [
-            { index: true, element: <DashboardPage /> },
+            { index: true, element: <IndexRedirect /> },
             { path: 'guide', element: <GuidePage /> },
             { path: 'reports', element: <ReportsPage /> },
             { path: 'report/new', element: <ReportFormPage /> },
             { path: 'messages', element: <MessagesPage /> },
-            { path: 'volunteers', element: <VolunteersPage /> },
+            { path: 'volunteers', element: <RoleGuard allowedRoles={['supervisor', 'official']}><VolunteersPage /></RoleGuard> },
             { path: 'profile', element: <ProfilePage /> },
             { path: 'notifications', element: <NotificationsPage /> },
             { path: '*', element: <NotFoundPage /> },

--- a/src/router/RoleGuard.tsx
+++ b/src/router/RoleGuard.tsx
@@ -53,9 +53,9 @@ export default function RoleGuard({ allowedRoles, children }: RoleGuardProps) {
     if (!allowedRoles.includes(userProfile.role)) {
         // Redirect to the appropriate home based on the user's actual role
         const roleHome: Record<UserRole, string> = {
-            volunteer: '/volunteer',
-            supervisor: '/supervisor',
-            official: '/official',
+            volunteer: '/reports',
+            supervisor: '/',
+            official: '/',
         };
         return <Navigate to={roleHome[userProfile.role]} replace />;
     }


### PR DESCRIPTION
## Summary
- Removes the Dashboard link from the volunteer sidebar so volunteers only see Guide, Reports, and Messages
- Adds an `IndexRedirect` component that redirects volunteers from `/` to `/reports`, while showing the dashboard for supervisors/officials
- Wraps the `/volunteers` route with `RoleGuard` to restrict access to supervisors and officials
- Fixes `RoleGuard` redirect paths to match the flat routing structure (`/reports` for volunteers, `/` for supervisors/officials)

## Test plan
- [ ] Log in as volunteer → lands on `/reports`, no Dashboard or Volunteers links in sidebar
- [ ] Navigate to `/` as volunteer → redirected to `/reports`
- [ ] Navigate to `/volunteers` as volunteer → redirected to `/reports`
- [ ] Log in as supervisor → Dashboard and Volunteers visible, working normally
- [ ] Log in as official → Dashboard and Supervisors visible, working normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)