### PR TITLE
fix: align Report Case buttons to bottom of Guide page cards

### DIFF
--- a/src/pages/GuidePage.tsx
+++ b/src/pages/GuidePage.tsx
@@ -88,7 +88,7 @@ export function GuidePage() {
                             const recommendations = disease.guidance.split(',').map((r) => r.trim()).filter(Boolean);
                             return (
                                 <Card key={disease.id} className="hover:shadow-lg transition-shadow">
-                                    <CardContent className="pt-6">
+                                    <CardContent className="pt-6 flex-1 flex flex-col">
                                         <div className="flex items-start justify-between mb-4">
                                             <div className={`w-12 h-12 ${bg} rounded-xl flex items-center justify-center`}>
                                                 <Icon className={`w-6 h-6 ${color}`} />
@@ -113,7 +113,7 @@ export function GuidePage() {
                                                 ))}
                                             </ul>
                                         </div>
-                                        <Button className="w-full bg-blue-600 hover:bg-blue-700 text-white" onClick={() => handleReportCase(disease)}>
+                                        <Button className="w-full bg-blue-600 hover:bg-blue-700 text-white mt-auto" onClick={() => handleReportCase(disease)}>
                                             <Activity className="w-4 h-4 mr-2" />
                                             REPORT CASE
                                         </Button>


### PR DESCRIPTION
## Summary
- Fixed vertical misalignment of "Report Case" buttons on the Guide page disease cards
- Cards with varying content lengths now have buttons consistently pinned to the bottom
- Added flex layout (`flex-1 flex flex-col`) to `CardContent` and `mt-auto` to the button

## Test plan
- [ ] Open the Guide page and verify all Report Case buttons are aligned at the same height
- [ ] Check alignment across viewport widths (1-col, 2-col, 3-col layouts)
- [ ] Confirm buttons still navigate to the report form correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)