### PR TITLE
fix: improve conversation error handling and expand CI/CD deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
           path: dist/
 
   deploy:
-    name: Deploy to Firebase Hosting
+    name: Deploy to Firebase
     needs: ci
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -58,11 +58,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
+
+      - name: Install Cloud Functions dependencies
+        run: cd functions && npm ci
+
+      - name: Authenticate with Firebase
+        run: |
+          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "$RUNNER_TEMP/firebase-sa.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/firebase-sa.json" >> "$GITHUB_ENV"
+
+      - name: Deploy Firestore rules and indexes
+        run: npx firebase-tools deploy --only firestore:rules,firestore:indexes --project saha-care
+
+      - name: Deploy Cloud Functions
+        run: npx firebase-tools deploy --only functions --project saha-care
 
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -157,7 +157,11 @@ export function MessagesPage() {
             })
             .catch((err) => {
                 console.error('Failed to create conversation:', err);
-                setConversationError('Failed to start conversation. Please try again.');
+                // Show more specific error for permission issues
+                const message = err?.code === 'permission-denied'
+                    ? 'Permission denied. Firestore rules may need to be deployed.'
+                    : 'Failed to start conversation. Please try again.';
+                setConversationError(message);
                 setConversationLoading(false);
             });
     }, [searchParams, loading, conversations, firebaseUser?.uid, userProfile, conversationLoading]);


### PR DESCRIPTION
## Summary
- Adds specific error messaging for Firestore `permission-denied` errors when starting a conversation on MessagesPage, instead of a generic failure message.
- Expands the CI/CD deploy workflow to deploy Firestore rules, indexes, and Cloud Functions alongside hosting, ensuring server-side resources stay in sync with the app.

## Test plan
- [ ] Verify MessagesPage shows "Permission denied" message when Firestore rules block conversation creation
- [ ] Verify generic error message still appears for other failure types
- [ ] Confirm CI pipeline deploys Firestore rules, indexes, and Cloud Functions on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)