### PR TITLE
fix: remove danger signs section from active alerts and reports

### DIFF
--- a/src/components/reports/ReportDetailDialog.tsx
+++ b/src/components/reports/ReportDetailDialog.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, MapPin, Thermometer, Users, Clock } from 'lucide-react';
+import { MapPin, Thermometer, Users, Clock } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
 import { Badge } from '../ui/badge';
 import type { Report } from '../../types';
@@ -80,24 +80,6 @@ export function ReportDetailDialog({ report, open, onClose }: ReportDetailDialog
                                 {report.symptoms.map((symptom, idx) => (
                                     <Badge key={idx} variant="secondary" className="text-xs">
                                         {symptom}
-                                    </Badge>
-                                ))}
-                            </div>
-                        </div>
-                    )}
-
-                    {/* Danger signs */}
-                    {report.dangerSigns && report.dangerSigns.length > 0 && (
-                        <div>
-                            <p className="text-xs font-medium text-gray-500 mb-1">Danger Signs</p>
-                            <div className="flex flex-wrap gap-1">
-                                {report.dangerSigns.map((sign, idx) => (
-                                    <Badge
-                                        key={idx}
-                                        className="bg-red-100 text-red-700 hover:bg-red-100 text-xs"
-                                    >
-                                        <AlertTriangle className="h-3 w-3 mr-1" />
-                                        {sign}
                                     </Badge>
                                 ))}
                             </div>

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Filter, CheckCircle, X, AlertTriangle, MapPin, Thermometer, Users, Clock, MessageSquare } from 'lucide-react';
+import { Filter, CheckCircle, X, MapPin, Thermometer, Users, Clock, MessageSquare } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
@@ -143,16 +143,6 @@ export function ReportsPage() {
                                     <div className="flex flex-wrap gap-1">
                                         {report.symptoms.map((symptom, idx) => (
                                             <Badge key={idx} variant="secondary" className="text-xs">{symptom}</Badge>
-                                        ))}
-                                    </div>
-                                )}
-                                {report.dangerSigns && report.dangerSigns.length > 0 && (
-                                    <div className="flex flex-wrap gap-1">
-                                        {report.dangerSigns.map((sign, idx) => (
-                                            <Badge key={idx} className="bg-red-100 text-red-700 hover:bg-red-100 text-xs">
-                                                <AlertTriangle className="h-3 w-3 mr-1" />
-                                                {sign}
-                                            </Badge>
                                         ))}
                                     </div>
                                 )}


### PR DESCRIPTION
## Summary
- Removed the danger signs display from the report detail dialog (opened via "View Report" in the Active Alerts section on the dashboard)
- Removed the danger sign red badges from report cards in the Reports page
- Cleaned up now-unused `AlertTriangle` imports from both files

## Test plan
- [ ] Navigate to Dashboard → expand an active alert → click "View Report" — confirm no danger signs section appears
- [ ] Navigate to Reports page — confirm no danger sign red badges appear in report cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)