### PR TITLE
fix: deep-strip undefined values to fix report submission errors

### DIFF
--- a/src/services/__tests__/reports.test.ts
+++ b/src/services/__tests__/reports.test.ts
@@ -137,6 +137,43 @@ describe('Reports Service', () => {
       expect(savedReport.createdAt).toBeDefined();
     });
 
+    it('strips nested undefined values before saving to Firestore', async () => {
+      mockAddDoc.mockResolvedValue({ id: 'new-report-id' });
+
+      const reportData = {
+        disease: 'Acute Watery Diarrhea',
+        answers: [
+          {
+            questionId: 'awd-q1',
+            questionText: 'Loose stools?',
+            answer: true,
+            numericValue: undefined,
+          },
+        ],
+        symptoms: ['Loose stools?'],
+        location: { lat: 31.5, lng: 34.45, name: undefined },
+        reporterId: 'test-uid-123',
+        reporterName: 'Test User',
+        region: 'north-gaza',
+        hasDangerSigns: false,
+        isImmediateReport: false,
+        personsCount: 1,
+      };
+
+      await createReport(reportData as Parameters<typeof createReport>[0]);
+
+      const addDocCall = mockAddDoc.mock.calls[0];
+      const savedReport = addDocCall[1];
+
+      // Nested undefined in location.name should be stripped
+      expect(savedReport.location).not.toHaveProperty('name');
+      // Nested undefined in answers[].numericValue should be stripped
+      expect(savedReport.answers[0]).not.toHaveProperty('numericValue');
+      // Other fields should still be present
+      expect(savedReport.location.lat).toBe(31.5);
+      expect(savedReport.answers[0].answer).toBe(true);
+    });
+
     it('throws error if Firestore fails', async () => {
       mockAddDoc.mockRejectedValue(new Error('Firestore error'));
 

--- a/src/services/reports.ts
+++ b/src/services/reports.ts
@@ -17,6 +17,25 @@ import type { Report, ReportLocation, QuestionAnswer } from '../types';
 
 const REPORTS_COLLECTION = 'reports';
 
+function stripUndefined(obj: Record<string, unknown>): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+        if (value === undefined) continue;
+        if (Array.isArray(value)) {
+            result[key] = value.map(item =>
+                item !== null && typeof item === 'object' && !Array.isArray(item)
+                    ? stripUndefined(item as Record<string, unknown>)
+                    : item
+            );
+        } else if (value !== null && typeof value === 'object') {
+            result[key] = stripUndefined(value as Record<string, unknown>);
+        } else {
+            result[key] = value;
+        }
+    }
+    return result;
+}
+
 const CASE_ID_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
 
 function generateCaseId(): string {
@@ -50,9 +69,7 @@ export async function createReport(data: {
 }): Promise<{ id: string; caseId: string }> {
     const caseId = generateCaseId();
     // Strip undefined values — Firestore rejects them
-    const cleanData = Object.fromEntries(
-        Object.entries(data).filter(([, v]) => v !== undefined)
-    );
+    const cleanData = stripUndefined(data as unknown as Record<string, unknown>);
     const docRef = await addDoc(collection(db, REPORTS_COLLECTION), {
         ...cleanData,
         caseId,


### PR DESCRIPTION
## Summary

- Report submission was failing with "Failed to submit report" because Firestore rejects `undefined` values, and `createReport` only stripped top-level undefineds — nested ones in `location.name` and `answers[].numericValue` were passed through.
- Replaced shallow `Object.fromEntries` filtering with a recursive `stripUndefined` helper that cleans nested objects and arrays.
- Added test verifying nested undefined values are stripped before Firestore write.

## Test plan
- [x] `npx vitest run src/services/__tests__/reports.test.ts` — all 10 tests pass
- [x] `npm run build` — no type errors