### PR TITLE
fix: handle fake reporter IDs in conversations and improve seed script

### DIFF
--- a/scripts/seedReports.ts
+++ b/scripts/seedReports.ts
@@ -26,8 +26,8 @@ const __dirname = dirname(__filename);
 
 const TOTAL_REPORTS = 150;
 
-/** Volunteer user IDs — replace with real UIDs from your Firestore users collection */
-const VOLUNTEER_IDS = [
+/** Fallback volunteer user IDs used when no real approved volunteers are found in Firestore */
+const FALLBACK_VOLUNTEER_IDS = [
     { uid: 'volunteer-1', name: 'Amira Hassan', region: 'Gaza City' },
     { uid: 'volunteer-2', name: 'Youssef Khalil', region: 'North Gaza' },
     { uid: 'volunteer-3', name: 'Fatima Al-Masri', region: 'Deir al-Balah' },
@@ -38,7 +38,8 @@ const VOLUNTEER_IDS = [
     { uid: 'volunteer-8', name: 'Hana Qassem', region: 'Khan Younis' },
 ];
 
-const SUPERVISOR_IDS = [
+/** Fallback supervisor UIDs used when no real approved supervisors are found in Firestore */
+const FALLBACK_SUPERVISOR_IDS = [
     'supervisor-1',
     'supervisor-2',
     'supervisor-3',
@@ -75,6 +76,37 @@ const DISEASES = [
     { disease: 'Suspected Pertussis (Whooping Cough)', weight: 4 },
     { disease: 'Suspected Diphtheria', weight: 3 },
 ];
+
+// ─── Real User Fetching ───
+
+interface VolunteerEntry {
+    uid: string;
+    name: string;
+    region: string;
+}
+
+/**
+ * Fetches real approved volunteers and supervisors from Firestore.
+ * Returns fallback arrays if none are found.
+ */
+async function fetchRealUsers(db: Firestore): Promise<{ volunteers: VolunteerEntry[]; supervisors: string[] }> {
+    const usersCollection = db.collection('users');
+
+    const [volunteerSnap, supervisorSnap] = await Promise.all([
+        usersCollection.where('role', '==', 'volunteer').where('status', '==', 'approved').get(),
+        usersCollection.where('role', '==', 'supervisor').where('status', '==', 'approved').get(),
+    ]);
+
+    const volunteers: VolunteerEntry[] = volunteerSnap.docs.map((doc) => ({
+        uid: doc.id,
+        name: (doc.data().displayName as string) || 'Unknown',
+        region: (doc.data().region as string) || 'Gaza City',
+    }));
+
+    const supervisors: string[] = supervisorSnap.docs.map((doc) => doc.id);
+
+    return { volunteers, supervisors };
+}
 
 // ─── Helper functions ───
 
@@ -277,12 +309,12 @@ interface SeedReport {
     verificationNotes?: string;
 }
 
-function generateReports(count: number): SeedReport[] {
+function generateReports(count: number, volunteerIds: VolunteerEntry[], supervisorIds: string[]): SeedReport[] {
     const reports: SeedReport[] = [];
 
     for (let i = 0; i < count; i++) {
         const disease = weightedPick(DISEASES);
-        const volunteer = pick(VOLUNTEER_IDS);
+        const volunteer = pick(volunteerIds);
         const region = volunteer.region;
         const coords = REGION_COORDS[region];
         const locationNames = LOCATION_NAMES[region];
@@ -325,7 +357,7 @@ function generateReports(count: number): SeedReport[] {
 
         // Add verification metadata for verified/rejected reports
         if (status === 'verified' || status === 'rejected') {
-            report.verifiedBy = pick(SUPERVISOR_IDS);
+            report.verifiedBy = pick(supervisorIds);
             report.verifiedAt = new Date(createdAt.getTime() + randomInt(1, 48) * 60 * 60 * 1000); // 1-48h after creation
             if (status === 'rejected') {
                 report.verificationNotes = pick([
@@ -387,7 +419,30 @@ function initializeFirebaseAdmin(useEmulator: boolean): Firestore {
 
 async function seedReports(db: Firestore): Promise<void> {
     const coll = db.collection('reports');
-    const reports = generateReports(TOTAL_REPORTS);
+
+    // Fetch real users from Firestore, falling back to hardcoded arrays if none found
+    console.log('Fetching real users from Firestore...');
+    const { volunteers: realVolunteers, supervisors: realSupervisors } = await fetchRealUsers(db);
+
+    let volunteerIds: VolunteerEntry[];
+    if (realVolunteers.length > 0) {
+        console.log(`  Found ${realVolunteers.length} approved volunteer(s) — using real UIDs`);
+        volunteerIds = realVolunteers;
+    } else {
+        console.warn('  WARNING: No approved volunteers found in Firestore — using fallback IDs');
+        volunteerIds = FALLBACK_VOLUNTEER_IDS;
+    }
+
+    let supervisorIds: string[];
+    if (realSupervisors.length > 0) {
+        console.log(`  Found ${realSupervisors.length} approved supervisor(s) — using real UIDs`);
+        supervisorIds = realSupervisors;
+    } else {
+        console.warn('  WARNING: No approved supervisors found in Firestore — using fallback IDs');
+        supervisorIds = FALLBACK_SUPERVISOR_IDS;
+    }
+
+    const reports = generateReports(TOTAL_REPORTS, volunteerIds, supervisorIds);
 
     console.log(`\nSeeding ${reports.length} reports...\n`);
 

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -77,6 +77,9 @@ export function MessagesPage() {
 
     const quickReplies = isVolunteer ? volunteerQuickReplies : supervisorQuickReplies;
 
+    const isFakeVolunteerId = (id: string) =>
+        !id || id.length < 20 || /^(volunteer|supervisor|user)-\d+$/.test(id);
+
     // Get the other party's name for a conversation
     const getOtherName = (conv: Conversation) =>
         isVolunteer ? conv.supervisorName : conv.volunteerName;
@@ -156,11 +159,16 @@ export function MessagesPage() {
                 // onSnapshot will pick up the new conversation; the effect re-runs to select it
             })
             .catch((err) => {
-                console.error('Failed to create conversation:', err);
+                console.error('Failed to create conversation:', err, { reportId, volunteerId, volunteerName });
                 // Show more specific error for permission issues
-                const message = err?.code === 'permission-denied'
-                    ? 'Permission denied. Firestore rules may need to be deployed.'
-                    : 'Failed to start conversation. Please try again.';
+                let message: string;
+                if (isFakeVolunteerId(volunteerId)) {
+                    message = 'Cannot message this volunteer — the report was created with test data. Re-seed reports with real user accounts.';
+                } else if (err?.code === 'permission-denied') {
+                    message = 'Permission denied. Firestore rules may need to be deployed.';
+                } else {
+                    message = 'Failed to start conversation. Please try again.';
+                }
                 setConversationError(message);
                 setConversationLoading(false);
             });
@@ -174,6 +182,8 @@ export function MessagesPage() {
 
         const unsubscribe = subscribeToMessages(selectedConversation.id, (msgs) => {
             setMessages(msgs);
+        }, (error) => {
+            console.error('Messages subscription error:', error);
         });
 
         return () => unsubscribe();

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -95,7 +95,14 @@ export function ReportsPage() {
         navigate(`/messages?${params.toString()}`);
     };
 
-    const ReportCard = ({ report, showActions = true }: { report: Report; showActions?: boolean }) => (
+    const isFakeReporterId = (reporterId: string) => {
+        // Firebase UIDs are typically 28+ chars; placeholder IDs like "volunteer-1" are short
+        return !reporterId || reporterId.length < 20 || /^(volunteer|supervisor|user)-\d+$/.test(reporterId);
+    };
+
+    const ReportCard = ({ report, showActions = true }: { report: Report; showActions?: boolean }) => {
+        const fakeReporter = isFakeReporterId(report.reporterId);
+        return (
         <Card className="hover:shadow-md transition-shadow">
             <CardContent className="pt-6">
                 <div className="space-y-3">
@@ -172,10 +179,12 @@ export function ReportsPage() {
                         <Button
                             variant="outline"
                             size="sm"
-                            className="border-teal-500 text-teal-600 hover:bg-teal-50"
+                            className={`border-teal-500 text-teal-600 hover:bg-teal-50${fakeReporter ? ' opacity-50 cursor-not-allowed' : ''}`}
+                            disabled={fakeReporter}
+                            title={fakeReporter ? 'Cannot message — report created with test data' : ''}
                             onClick={(e) => {
                                 e.stopPropagation();
-                                handleMessage(report);
+                                if (!fakeReporter) handleMessage(report);
                             }}
                         >
                             <MessageSquare className="h-4 w-4 mr-2" />
@@ -197,7 +206,8 @@ export function ReportsPage() {
                 </div>
             </CardContent>
         </Card>
-    );
+        );
+    };
 
     return (
         <div className="space-y-6">

--- a/src/services/conversations.ts
+++ b/src/services/conversations.ts
@@ -55,7 +55,8 @@ export function subscribeToConversations(
  */
 export function subscribeToMessages(
     conversationId: string,
-    callback: (msgs: Message[]) => void
+    callback: (msgs: Message[]) => void,
+    onError?: (error: Error) => void
 ): Unsubscribe {
     const q = query(
         collection(db, CONVERSATIONS_COLLECTION, conversationId, MESSAGES_SUBCOLLECTION),
@@ -69,6 +70,9 @@ export function subscribeToMessages(
             sentAt: d.data().sentAt?.toDate() || new Date(),
         })) as Message[];
         callback(msgs);
+    }, (error) => {
+        console.error('Failed to load messages:', error);
+        onError?.(error);
     });
 }
 


### PR DESCRIPTION
## Summary
- **Seed script** now fetches real approved volunteer/supervisor UIDs from Firestore instead of using hardcoded placeholder IDs (`volunteer-1`, etc.), falling back with a warning if none are found.
- **ReportsPage** disables the "Message" button for reports with fake/placeholder reporter IDs, showing a tooltip explaining the report was created with test data.
- **MessagesPage** detects fake volunteer IDs in the conversation creation flow and shows a specific error message instead of a generic failure. Also passes an error handler to `subscribeToMessages`.
- **conversations.ts** adds an optional `onError` callback to `subscribeToMessages`, matching the existing `subscribeToConversations` pattern.

## Test plan
- [ ] Seed reports with real volunteer accounts in Firestore and verify "Message" works
- [ ] Verify old seeded reports with fake IDs show a disabled Message button with tooltip
- [ ] Verify clicking "Message" on a fake-ID report from URL params shows a clear error
- [ ] Check browser console for proper error logging on subscription failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)