### PR TITLE
fix: hide Danger Signs (Any Disease) alerts from dashboard

### DIFF
--- a/src/components/charts/AlertsPanel.tsx
+++ b/src/components/charts/AlertsPanel.tsx
@@ -41,7 +41,7 @@ export default function AlertsPanel() {
                     </div>
                 ) : (
                     <ul className="divide-y divide-gray-100">
-                        {alerts.map((alert) => (
+                        {alerts.filter(a => a.disease !== 'Danger Signs (Any Disease)').map((alert) => (
                             <li key={alert.id} className="py-3">
                                 <div className="flex items-center gap-2 flex-wrap">
                                     <span className="text-sm font-semibold">{alert.disease}</span>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -120,6 +120,7 @@ export function DashboardPage() {
     }, [userProfile?.region, userProfile?.role, refreshKey]);
 
     const filteredAlerts = alerts.filter((alert) => {
+        if (alert.disease === 'Danger Signs (Any Disease)') return false;
         const windowLabel = formatWindowHours(alert.windowHours);
         const matchesTime =
             timeFilter === 'all' ||


### PR DESCRIPTION
## Summary
- Filters out "Danger Signs (Any Disease)" alerts from the main dashboard alert list and the sidebar AlertsPanel
- Alerts are still created in Firestore by the cloud function but no longer rendered in dashboard views

## Test plan
- [ ] Open the dashboard and verify "Danger Signs (Any Disease)" alerts no longer appear
- [ ] Verify other disease alerts still display correctly in both the main alert list and sidebar panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)