### PR TITLE
fix: wire up Submit Report button in My Reports empty state

### DIFF
--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -271,7 +271,7 @@ export function ReportsPage() {
                             <Card>
                                 <CardContent className="py-12 text-center">
                                     <p className="text-gray-500 mb-4">You haven't submitted any reports yet</p>
-                                    <Button className="bg-blue-600 hover:bg-blue-700">Submit Report</Button>
+                                    <Button className="bg-blue-600 hover:bg-blue-700" onClick={() => navigate('/report/new')}>Submit Report</Button>
                                 </CardContent>
                             </Card>
                         )}


### PR DESCRIPTION
## Summary
- The "Submit Report" button in the My Reports tab's empty state was missing an `onClick` handler, making it non-functional
- Added navigation to `/report/new` so it behaves the same as the main submit report action

## Test plan
- [ ] Go to Reports tab → My Reports (with no existing reports)
- [ ] Click the "Submit Report" button
- [ ] Verify it navigates to the report form page (`/report/new`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)