### PR TITLE
fix: remove unnecessary single-field Firestore index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -227,16 +227,6 @@
             "queryScope": "COLLECTION",
             "fields": [
                 {
-                    "fieldPath": "createdAt",
-                    "order": "DESCENDING"
-                }
-            ]
-        },
-        {
-            "collectionGroup": "reports",
-            "queryScope": "COLLECTION",
-            "fields": [
-                {
                     "fieldPath": "disease",
                     "order": "ASCENDING"
                 },


### PR DESCRIPTION
## Summary
- Removes the single-field `reports/createdAt` index from `firestore.indexes.json` that Firestore auto-creates, which was causing a 400 error during deploy

## Test plan
- [ ] Verify CI/CD deploy pipeline passes the "Deploy Firestore rules and indexes" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)