### PR TITLE
fix: raise profile dropdown z-index above header app bar

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -101,7 +101,7 @@ export function Header() {
                                 </div>
                             </Button>
                         </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-56">
+                        <DropdownMenuContent align="end" className="w-56 z-[1002]">
                             <DropdownMenuItem onClick={() => navigate('/profile')}>
                                 <User className="mr-2 h-4 w-4" />
                                 Profile Settings


### PR DESCRIPTION
## Summary
- Fixes the profile dropdown menu (Profile Settings + Logout) being hidden behind the header app bar
- The header uses `z-[1001]` but the dropdown defaulted to `z-50`, so it rendered underneath
- Adds `z-[1002]` to the `DropdownMenuContent` in `Header.tsx` so it stacks above the header

## Test plan
- [ ] Log in and click the profile avatar in the top-right corner
- [ ] Verify the dropdown (Profile Settings, Logout) is fully visible and not clipped by the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)