### PR TITLE
fix: center login page logo with mx-auto

### DIFF
--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -44,7 +44,7 @@ export function LoginPage() {
       <div className="w-full max-w-md">
         {/* Logo and Title */}
         <div className="text-center mb-8">
-          <img src="/logo.png" alt="SAHA-Care" className="w-16 h-16 rounded-2xl shadow-sm mb-4" />
+          <img src="/logo.png" alt="SAHA-Care" className="mx-auto w-16 h-16 rounded-2xl shadow-sm mb-4" />
           <h1 className="text-3xl text-gray-900 mb-2">SAHA-Care</h1>
           <p className="text-gray-600">Humanitarian Health Network Access</p>
         </div>


### PR DESCRIPTION
Adds `mx-auto` to the login page logo `<img>` element so it is horizontally centered within its parent container. The `text-center` on the parent div alone was insufficient since the image is a block-level element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)