### PR TITLE
fix: resolve guide disease preselection race condition

### DIFF
--- a/src/pages/ReportFormPage.tsx
+++ b/src/pages/ReportFormPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { toast } from 'sonner';
 import { Search, MapPin, AlertTriangle, CheckCircle, ChevronRight, Pencil } from 'lucide-react';
@@ -101,6 +101,18 @@ export function ReportFormPage() {
         region: userProfile?.region || 'Rafah',
     });
     const [submitLoading, setSubmitLoading] = useState(false);
+
+    useEffect(() => {
+        if (preselectedDisease && !selectedDisease) {
+            const match = diseases.find(
+                (d) => d.id === preselectedDisease.id || d.name === preselectedDisease.disease
+            );
+            if (match) {
+                setSelectedDisease(match);
+                setStep(2);
+            }
+        }
+    }, [diseases]);
 
     const handleMapLocationSelect = (location: ReportLocation) => {
         setLocationData((prev) => ({


### PR DESCRIPTION
When navigating from the Guide page via "REPORT CASE", the disease preselection in `ReportFormPage` only ran during `useState` initialization. If Firestore `caseDefinitions` hadn't loaded yet, the code fell back to 3 fallback diseases, causing the 7 other diseases to never be preselected.

Added a `useEffect` that watches the `diseases` array and re-applies the preselection once definitions load, without overriding any manually selected disease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)